### PR TITLE
Positioning the social links

### DIFF
--- a/source/stylesheets/components/_team_grid.scss
+++ b/source/stylesheets/components/_team_grid.scss
@@ -17,6 +17,9 @@
 //   <div class="TeamGrid-cell">
 //     <div>Cell 3</div>
 //   </div>
+//   <div class="TeamGrid-cell">
+//     <div>Cell 4</div>
+//   </div>
 // </div>
 //
 // sg-wrapper:
@@ -32,6 +35,9 @@ $susy: (
 );
 
 .TeamGrid {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
   max-width: $Theme-grid-maxWidth;
   margin-right: auto;
   margin-left: auto;

--- a/source/stylesheets/components/_team_member.scss
+++ b/source/stylesheets/components/_team_member.scss
@@ -81,6 +81,8 @@ $TeamMember-max-width-small: 150px;
 
 .TeamMember-bio {
   @include font-properties(bodyText, base);
+
+  flex-grow: 1;
 }
 
 .TeamMember-social {


### PR DESCRIPTION
The social links should all be align by the ones of the highest column.

My approach was to make the columns all the same height and then absolutely positioning the links. Since absolutely positioned elements take no space, I had to add some extra margins, to make space for them. This should not be a big issue, since they are always the same height.
