### PR TITLE
Improves the styleguides for local components

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -43,18 +43,18 @@ namespace :styleguide do
     Tempfile.open(['all', '.css']) do |f|
       f.write compile_stylesheets
       f.flush
-      sh "rm -rf #{output_folder}; mkdir #{output_folder}; cp source/images/* #{output_folder}"
+      sh "rm -rf #{output_folder}; mkdir #{output_folder}; cp -R source/images/* #{output_folder}"
       sh styleguide_command(f.path, output_folder, watch)
     end
   end
 
   def compile_stylesheets
-    `bundle exec sass --load-path vendor/blue/stylesheets --load-path vendor/blue/images --load-path bower_components --require font-awesome-sass source/stylesheets/all.scss`
+    `bundle exec sass --load-path vendor/blue/stylesheets --load-path vendor/blue/images --load-path bower_components --require susy --require font-awesome-sass source/stylesheets/all.scss`
   end
 
   def styleguide_command(style_source, output_folder, watch)
     kss_sources = ['source/stylesheets/**/*.scss', 'vendor/blue/stylesheets/**/*.scss']
-    options = [
+    [
       './node_modules/.bin/styleguide',
       '--server',
       "#{watch ? '--watch' : ''}",

--- a/source/stylesheets/components/_numbered_steps.scss
+++ b/source/stylesheets/components/_numbered_steps.scss
@@ -32,7 +32,7 @@
 //   </li>
 // </ul>
 //
-// Styleguide 5.4
+// Styleguide 5.6
 
 @import 'blue/theme_vars';
 

--- a/source/stylesheets/components/_panel.scss
+++ b/source/stylesheets/components/_panel.scss
@@ -1,16 +1,19 @@
 // Panel
 //
-// Full width container with a unique background
+// Full width container with a unique background. The height is defined by the content.
 //
 // .Panel--home - A panel with a background to be used in the homepage
 // .Panel--subvisualCaseStudy - A panel with a background to be used as the subvisual case study
 // .Panel--creatorsSchoolCaseStudy - A panel with a background to be used as the creators school case study
 // .Panel--fishTank - A panel with a background that is a map of our HQ
+// .Panel--sam - A panel with a background that is a picture of a client (Sam)
+// .Panel--rob - A panel with a background that is a picture of a client (Rob)
+// .Panel--company - A panel with a background to be used in the company page
+// .Panel--team - A panel with a background to be used in the team's page
+// .Panel--clients - A panel with a background that is a world map with all of our clients
 //
 // markup:
-// <div class="Panel {$modifiers}">
-//   The content defines the Panel's height<br>
-// </div>
+// <div class="Panel {$modifiers}" style="height: 500px"></div>
 //
 // Styleguide 5.1
 

--- a/source/stylesheets/components/_ratio_enforcer.scss
+++ b/source/stylesheets/components/_ratio_enforcer.scss
@@ -1,15 +1,13 @@
 // RatioEnforcer
 //
 // Forces the image to adapt to its container's dimensions but maintaing its natural ratio.
-// Supposed to be applied to an image
+// Supposed to be applied to an image.
 //
-// default - Natural growth
-// .RatioEnforcer--creatorsSchoolLogo - Custom ratio for Creator's School logo
-// .RatioEnforcer--rubyconfptLogo - Custom ratio for Creator's School logo
-// .RatioEnforcer--roundedLogo - Custom ratio for rounded logo like meetups
+// In situations where custom dimensions are needed for a specific image, it
+// should be defined here as a modifier.
 //
 // markup:
-// <img src="/placeholder.png" class="RatioEnforcer {$modifiers}">
+// <img src="/placeholder.png" class="RatioEnforcer">
 //
 // Styleguide 5.2
 

--- a/source/stylesheets/components/_separator_image.scss
+++ b/source/stylesheets/components/_separator_image.scss
@@ -1,15 +1,19 @@
 // SeparatorImage
 //
-// Centers an image between two panels.
+// Centers an image between two visual containers (e.g. Panel).
 // Used on services pages
 //
 // markup:
 // <div class="SeparatorImage">
-//   <div class="SeparatorImage-image>
-//     <img src="/placeholder.png">
+//   <div class="SeparatorImage-image">
+//     <img src="/placeholder.png" style="width: 100px">
 //   </div>
-//   <div class="SeparatorImage-marginFixer"></div>
 // </div>
+//
+// sg-wrapper:
+// <div style="min-height: 100px; background-color: rebeccapurple;"></div>
+// <sg-wrapper-content/>
+// <div style="min-height: 100px; background-color: lightblue;"></div>
 //
 // Styleguide 5.3
 

--- a/source/stylesheets/components/_team_member.scss
+++ b/source/stylesheets/components/_team_member.scss
@@ -6,9 +6,7 @@
 //
 // markup:
 // <div class="TeamMember">
-//   <div class="TeamMember-picture">
-//     <img src="img.png">
-//   </div>
+//   <img src="/team/zamith.jpg" class="TeamMember-picture"/>
 //   <h2 class="TeamMember-name">
 //     Person Name
 //   </h2>
@@ -16,7 +14,10 @@
 //     Developer
 //   </p>
 //   <hr class="TeamMember-separator">
-//   <p.class="TeamMember-social">
+//   <p class="TeamMember-bio">
+//     I am a member of Subvisual.
+//   </p>
+//   <p class="TeamMember-social">
 //     <a href="twitter.com/person">
 //       <img src="icons/twitter.png" class="TeamMember-socialLink">
 //     </a>


### PR DESCRIPTION
For the RatioEnforcer I decided to remove the modifiers because they are
so specific they add little to the documentation. Maybe if they were
tied together with the images they are supposed to be used with, it
would be more helpful.

As for the Panels, I went to on the opposite direction, because I think
it is helpful to look at all the different panels we have (and the fact
they are visually pleasing doesn't hurt either).

I added some inline styles here and there, to make the styleguide look
nicer (IMO), I'm assuming whoever reads this will understand that the
inline styles are not to be copied, but maybe we should write that down
somewhere and assume nothing.
