### PR TITLE
Prefetch company and join_us hero

### DIFF
--- a/source/layouts/layout.slim
+++ b/source/layouts/layout.slim
@@ -36,6 +36,7 @@ html.Theme itemscope='' itemtype='http://schema.org/WebPage' lang=data.site.lang
     - if current_page.data.preferred_url
       link rel='canonical' href=current_page.data.preferred_url
 
+    = yield_content :prefetch
     = stylesheet_link_tag 'all'
     = yield_content :stylesheets
 

--- a/source/partials/company/_hero.slim
+++ b/source/partials/company/_hero.slim
@@ -1,3 +1,6 @@
+- content_for :prefetch do
+  link rel="prefetch" href="#{ image_path('company_hero.jpg') }"
+
 .u-doubleLargeMargin
 .ContentFormatter.ContentFormatter--centerHorizontally
   h1.Heading.Heading--brandLarge

--- a/source/partials/company/join-us/_hero.slim
+++ b/source/partials/company/join-us/_hero.slim
@@ -1,3 +1,6 @@
+- content_for :prefetch do
+  link rel="prefetch" href="#{ image_path('company_join_us.jpg') }"
+
 .u-doubleLargeMargin
 .HorizontalGrid.HorizontalGrid--limited.u-doubleLargeMargin
   .HorizontalGrid-cell


### PR DESCRIPTION
This images needs to be prefetched so that they are available at the time the
page renders for the first time. The reason other images don't need to be
prefetched is because they are being used with the img tag.
