### PR TITLE
Add noscript fallbacks to Title and LoadPlaceholder

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "gatsby": "^2.1.18",
-    "gatsby-image": "^2.0.35",
+    "gatsby-image": "^2.0.38",
     "gatsby-plugin-google-analytics": "^2.0.18",
     "gatsby-plugin-manifest": "^2.0.19",
     "gatsby-plugin-offline": "^2.0.24",

--- a/src/common/useDetectJavascript.js
+++ b/src/common/useDetectJavascript.js
@@ -4,8 +4,8 @@ export default function useDetectJavascript() {
   const [hasJavascript, setJavascript] = useState(false)
 
   useLayoutEffect(() => {
-    if (typeof window !== 'undefined') setJavascript(true)
+    if (typeof window !== "undefined") setJavascript(true)
   }, [])
 
-  return hasJavascript;
+  return hasJavascript
 }

--- a/src/common/useDetectJavascript.js
+++ b/src/common/useDetectJavascript.js
@@ -1,0 +1,11 @@
+import { useState, useLayoutEffect } from "react"
+
+export default function useDetectJavascript() {
+  const [hasJavascript, setJavascript] = useState(false)
+
+  useLayoutEffect(() => {
+    if (typeof window !== 'undefined') setJavascript(true)
+  }, [])
+
+  return hasJavascript;
+}

--- a/src/components/PageTitle/index.js
+++ b/src/components/PageTitle/index.js
@@ -3,8 +3,8 @@ import classnames from "classnames"
 
 import "./index.module.css"
 
-const PageTitle = ({ children, regularFont }) => (
-  <h1 styleName={classnames("root", { "regular-font": regularFont })}>
+const PageTitle = ({ children, withTitle }) => (
+  <h1 styleName={classnames("root", { "with-title": withTitle })}>
     {children}
   </h1>
 )

--- a/src/components/PageTitle/index.js
+++ b/src/components/PageTitle/index.js
@@ -3,8 +3,8 @@ import classnames from "classnames"
 
 import "./index.module.css"
 
-const PageTitle = ({ children, withTitle }) => (
-  <h1 styleName={classnames("root", { "with-title": withTitle })}>
+const PageTitle = ({ children, withTittle }) =>  (
+  <h1 styleName={classnames("root", { "with-tittle": withTittle })}>
     {children}
   </h1>
 )

--- a/src/components/PageTitle/index.js
+++ b/src/components/PageTitle/index.js
@@ -1,7 +1,12 @@
 import React from "react"
+import classnames from "classnames"
 
 import "./index.module.css"
 
-const PageTitle = ({ children }) => <h1 styleName="root">{children}</h1>
+const PageTitle = ({ children, regularFont }) => (
+  <h1 styleName={classnames("root", { "regular-font": regularFont })}>
+    {children}
+  </h1>
+)
 
 export default PageTitle

--- a/src/components/PageTitle/index.module.css
+++ b/src/components/PageTitle/index.module.css
@@ -6,7 +6,7 @@
   color: #045cfc;
 }
 
-.with-title {
+.with-tittle {
   font-family: "Acta Display";
 }
 

--- a/src/components/PageTitle/index.module.css
+++ b/src/components/PageTitle/index.module.css
@@ -6,6 +6,10 @@
   color: #045cfc;
 }
 
+.regular-font {
+  font-family: "Acta Display";
+}
+
 @media (min-width: 950px) {
   .root {
     font-size: 112px;

--- a/src/components/PageTitle/index.module.css
+++ b/src/components/PageTitle/index.module.css
@@ -6,7 +6,7 @@
   color: #045cfc;
 }
 
-.regular-font {
+.with-title {
   font-family: "Acta Display";
 }
 

--- a/src/components/home/Hero/Title.js
+++ b/src/components/home/Hero/Title.js
@@ -10,24 +10,23 @@ import "./Title.module.css"
 const Title = ({ planetMorph }) => {
   const hasJavascript = useDetectJavascript()
 
-  if (hasJavascript) {
+  if (!hasJavascript)
     return (
-      <PageTitle>
-        We nurture{" "}
-        <span styleName="ideas">
-          ideas
-          <span styleName="planet">
-            <Planet morph={planetMorph} codeName="heroTittle" color="blue" />
-          </span>
-        </span>{" "}
+      <PageTitle withTittle>
+        We nurture <span styleName="ideas">ideas</span>{" "}
         <span styleName="glue">that empower</span> people
       </PageTitle>
     )
-  }
 
   return (
-    <PageTitle withTitle>
-      We nurture <span styleName="ideas">ideas</span>{" "}
+    <PageTitle>
+      We nurture{" "}
+      <span styleName="ideas">
+        ideas
+        <span styleName="planet">
+          <Planet morph={planetMorph} codeName="heroTittle" color="blue" />
+        </span>
+      </span>{" "}
       <span styleName="glue">that empower</span> people
     </PageTitle>
   )

--- a/src/components/home/Hero/Title.js
+++ b/src/components/home/Hero/Title.js
@@ -26,7 +26,7 @@ const Title = ({ planetMorph }) => {
   }
 
   return (
-    <PageTitle regularFont>
+    <PageTitle withTitle>
       We nurture <span styleName="ideas">ideas</span>{" "}
       <span styleName="glue">that empower</span> people
     </PageTitle>

--- a/src/components/home/Hero/Title.js
+++ b/src/components/home/Hero/Title.js
@@ -3,21 +3,35 @@ import PropTypes from "prop-types"
 
 import PageTitle from "../../PageTitle"
 import Planet from "../../Planet"
+import useDetectJavascript from "../../../common/useDetectJavascript"
 
 import "./Title.module.css"
 
-const Title = ({ planetMorph }) => (
-  <PageTitle>
-    We nurture{" "}
-    <span styleName="ideas">
-      ideas
-      <span styleName="planet">
-        <Planet morph={planetMorph} codeName="heroTittle" color="blue" />
-      </span>
-    </span>{" "}
-    <span styleName="glue">that empower</span> people
-  </PageTitle>
-)
+const Title = ({ planetMorph }) => {
+  const hasJavascript = useDetectJavascript()
+
+  if (hasJavascript) {
+    return (
+      <PageTitle>
+        We nurture{" "}
+        <span styleName="ideas">
+          ideas
+          <span styleName="planet">
+            <Planet morph={planetMorph} codeName="heroTittle" color="blue" />
+          </span>
+        </span>{" "}
+        <span styleName="glue">that empower</span> people
+      </PageTitle>
+    )
+  }
+
+  return (
+    <PageTitle regularFont>
+      We nurture <span styleName="ideas">ideas</span>{" "}
+      <span styleName="glue">that empower</span> people
+    </PageTitle>
+  )
+}
 
 Title.propTypes = {
   planetMorph: PropTypes.func,

--- a/src/html.js
+++ b/src/html.js
@@ -1,0 +1,37 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+export default function HTML(props) {
+  return (
+    <html {...props.htmlAttributes}>
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, shrink-to-fit=no"
+        />
+        {props.headComponents}
+      </head>
+      <body {...props.bodyAttributes}>
+        {props.preBodyComponents}
+        <noscript key="noscript" id="gatsby-noscript" />
+        <div
+          key={`body`}
+          id="___gatsby"
+          dangerouslySetInnerHTML={{ __html: props.body }}
+        />
+        {props.postBodyComponents}
+      </body>
+    </html>
+  )
+}
+
+HTML.propTypes = {
+  htmlAttributes: PropTypes.object,
+  headComponents: PropTypes.array,
+  bodyAttributes: PropTypes.object,
+  preBodyComponents: PropTypes.array,
+  body: PropTypes.string,
+  postBodyComponents: PropTypes.array,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4640,10 +4640,10 @@ gatsby-cli@^2.5.4:
     yargs "^12.0.5"
     yurnalist "^1.0.2"
 
-gatsby-image@^2.0.35:
-  version "2.0.37"
-  resolved "https://registry.yarnpkg.com/gatsby-image/-/gatsby-image-2.0.37.tgz#9c28c3d8c2a249f6f5eff929be67a761658762df"
-  integrity sha512-KdD5LefTmigun2NmvYqoBVXRZ0W0y3Rr9j+yOX6hxU+RJQb9u3gF3vG/dC0Aljwgo2T4zKBqG8wolJ7F2fWj5w==
+gatsby-image@^2.0.38:
+  version "2.0.38"
+  resolved "https://registry.yarnpkg.com/gatsby-image/-/gatsby-image-2.0.38.tgz#348b4a9ba690e1621ec53a7b60405ab525304a7d"
+  integrity sha512-c51nBwQuFlTffFrOs4nDI7fjS+OrWmniklzGSkmLhNojc4YVipYdYMDQLI252xYWzAjToUouCInFErlCTcEYRw==
   dependencies:
     "@babel/runtime" "^7.0.0"
     object-fit-images "^3.2.4"


### PR DESCRIPTION
* Render the default title font while scripts are not loaded on the `Title` component
* Add noscript tag to the `LoadPlaceholder` component, rendering it's children without the loading animation if there are no scripts
* Extends `html.js` and removes the default `noscript` message (this app works well with Javascript)