### PR TITLE
Replace package for intersection observer

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "0.1.0",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
+    "@researchgate/react-intersection-observer": "^0.7.4",
     "classnames": "^2.2.6",
     "gatsby": "^2.1.18",
     "gatsby-image": "^2.0.38",
@@ -24,7 +25,6 @@
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
     "react-helmet": "^5.2.0",
-    "react-intersection-observer": "^8.22.5",
     "react-morph": "0.4.0-alpha.1",
     "react-scroll-parallax": "^2.1.1"
   },

--- a/src/components/LoadPlaceholder/index.js
+++ b/src/components/LoadPlaceholder/index.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react"
 import { renderToStaticMarkup } from "react-dom/server"
-import Observer from "react-intersection-observer"
+import Observer from "@researchgate/react-intersection-observer"
 
 import useDetectJavascript from "../../common/useDetectJavascript"
 
@@ -15,9 +15,10 @@ export default function LoadPlaceholder({ delay = 0, dark, children }) {
 
   const onLoad = () => setLoaded(true)
 
-  const handleChange = isIntersecting => {
+  const handleChange = ({ isIntersecting }, unobserve) => {
     if (!isIntersecting) return
 
+    unobserve()
     setVisible(true)
   }
 
@@ -32,12 +33,16 @@ export default function LoadPlaceholder({ delay = 0, dark, children }) {
         }}
       />
       {hasJavascript ? (
-        <Observer onChange={handleChange} styleName="root">
-          <div
-            style={{ transitionDelay: `${delay}s` }}
-            styleName={`placeholder ${darkStyle} ${visible ? loadedStyle : ""}`}
-          />
-          {children(onLoad)}
+        <Observer onChange={handleChange}>
+          <div styleName="root">
+            <div
+              style={{ transitionDelay: `${delay}s` }}
+              styleName={`placeholder ${darkStyle} ${
+                visible ? loadedStyle : ""
+              }`}
+            />
+            {children(onLoad)}
+          </div>
         </Observer>
       ) : null}
     </>

--- a/src/components/Planet/index.js
+++ b/src/components/Planet/index.js
@@ -71,7 +71,7 @@ class Planet extends Component {
         </style>
         <ViewableMonitor styleName="monitor">
           {isViewable => {
-            if (!isViewable) return
+            if (!isViewable) return <div />
 
             return (
               <div {...morph} style={rootStyle} styleName="root">

--- a/src/components/ViewableMonitor/index.js
+++ b/src/components/ViewableMonitor/index.js
@@ -1,22 +1,13 @@
-import React, { Component } from "react"
-import Observer from "react-intersection-observer"
+import React, { useState } from "react"
+import Observer from "@researchgate/react-intersection-observer"
 
-export default class ViewableMonitor extends Component {
-  state = {
-    isIntersecting: false,
-  }
+export default function ViewableMonitor({ children, ...rest }) {
+  const [isIntersecting, setIsIntersecting] = useState(false)
+  const handleChange = ({ isIntersecting }) => setIsIntersecting(isIntersecting)
 
-  handleChange = isIntersecting => {
-    this.setState({ isIntersecting })
-  }
-
-  render() {
-    const { children, ...rest } = this.props
-
-    return (
-      <Observer {...rest} onChange={this.handleChange}>
-        {children(this.state.isIntersecting)}
-      </Observer>
-    )
-  }
+  return (
+    <Observer {...rest} onChange={handleChange}>
+      {children(isIntersecting)}
+    </Observer>
+  )
 }

--- a/src/components/home/Ventures/Portfolio/index.js
+++ b/src/components/home/Ventures/Portfolio/index.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types"
 import { StaticQuery, graphql } from "gatsby"
 
 import Planet from "../../../Planet"
-import ViewableMonitor from "../../../ViewableMonitor"
 import Venture from "./Venture"
 
 import "./index.module.css"
@@ -40,20 +39,14 @@ class Portfolio extends Component {
       <div styleName="root">
         <ul styleName="ventures">{ventures.map(this.renderVenture)}</ul>
         <div>
-          <ViewableMonitor styleName="planet">
-            {isViewable => {
-              if (!isViewable) return
-
-              return (
-                <Planet
-                  morph={planetMorph}
-                  codeName="venturesSubvisualPlanet"
-                  color="blue"
-                  hovering
-                />
-              )
-            }}
-          </ViewableMonitor>
+          <div styleName="planet">
+            <Planet
+              morph={planetMorph}
+              codeName="venturesSubvisualPlanet"
+              color="blue"
+              hovering
+            />
+          </div>
           <div styleName="planet">
             <Planet codeName="venturesPlanet1" color="purple" hovering />
           </div>

--- a/src/components/home/Ventures/Universe/index.js
+++ b/src/components/home/Ventures/Universe/index.js
@@ -2,25 +2,19 @@ import React from "react"
 import PropTypes from "prop-types"
 
 import Planet from "../../../Planet"
-import ViewableMonitor from "../../../ViewableMonitor"
 
 import "./index.module.css"
 
 const Universe = ({ subvisualPlanetMorph }) => (
   <div styleName="root">
-    <ViewableMonitor styleName="planet">
-      {isViewable => {
-        if (!isViewable) return
-
-        return (
-          <Planet
-            codeName="universeSubvisualPlanet"
-            morph={subvisualPlanetMorph}
-            color="blue"
-          />
-        )
-      }}
-    </ViewableMonitor>
+    <div styleName="planet">
+      <Planet
+        codeName="universeSubvisualPlanet"
+        morph={subvisualPlanetMorph}
+        color="blue"
+        hovering
+      />
+    </div>
     <svg viewBox="0 0 221 224" fill="none" xmlns="http://www.w3.org/2000/svg">
       <defs>
         <radialGradient

--- a/yarn.lock
+++ b/yarn.lock
@@ -826,6 +826,15 @@
     react-lifecycles-compat "^3.0.4"
     warning "^3.0.0"
 
+"@researchgate/react-intersection-observer@^0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@researchgate/react-intersection-observer/-/react-intersection-observer-0.7.4.tgz#9360274611beebd801e3c068294ddf2ab0d4b163"
+  integrity sha512-4F291saKAP9I25Qe1ePflvm1DLLA43GlBIZfpMFYWofph7CAm+19nT8xwkQqSszg4PwZa5BpkaI4tAEJHtlj3w==
+  dependencies:
+    invariant "^2.2.2"
+    prop-types "^15.6.0"
+    warning "^3.0.0"
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
@@ -5823,7 +5832,7 @@ into-stream@^3.1.0:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
 
-invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
+invariant@^2.2.0, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -8726,7 +8735,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -8970,14 +8979,6 @@ react-hot-loader@^4.6.2:
     react-lifecycles-compat "^3.0.4"
     shallowequal "^1.0.2"
     source-map "^0.7.3"
-
-react-intersection-observer@^8.22.5:
-  version "8.22.5"
-  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.22.5.tgz#831a7a4d6a470c428fff40a9da6d947141979776"
-  integrity sha512-iVPLXpg2tPIuKTyFodK+QZlNtLv5XC89yzzsWwTsPIPGOhbbbabo9RhNeUypc+miq5Iri+35/eRrSYGUl/79bA==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    invariant "^2.0.0"
 
 react-is@^16.7.0, react-is@^16.8.1:
   version "16.8.6"


### PR DESCRIPTION
Why:

* Apparently we're not using the recommended package for the
  intersection observer with react;
* Also, we need the extra flexibility provided by
  researchgate/react-intersection-observer.

This change addresses the need by:

* Replacing the package for the intersection observer with React;
* Refactoring the `LoadPlaceholder` and `ViewableMonitor` components to
  use the new package;
* Refactoring the `Planets` component to check for its own visibility,
  instead of relying on the outer components (important for animations
  as only one of the planets in the same animation can be visible at any
  given time).