### PR TITLE
Fix setup script on Yarn install

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -3,11 +3,9 @@
 # Install expected NodeJS version with ASDF VM
 asdf install
 
-# Install Yarn globally if necessary
-if ! command -v yarn >/dev/null 2>&1; then
-  npm install -g yarn
-  asdf reshim nodejs
-fi
+# Install or update Yarn globally
+npm install -g yarn
+asdf reshim nodejs
 
 # Install JavaScript dependencies
 yarn install


### PR DESCRIPTION
Why:

* ASDF is a prick with shims. You change the NodeJS version, but it
  keeps the shim file as an executable, which means normal script checks
  for an executable presence pass but then the shim fails because Yarn
  is not installed.

This change addresses the issue by:

* Changing the script to always try to install (or update) Yarn. A bit
  slower, but idempotent aswell.