### PR TITLE
Fix logo alignment on the about section

### DIFF
--- a/src/components/home/about_section.module.css
+++ b/src/components/home/about_section.module.css
@@ -36,8 +36,8 @@
 }
 
 .headerIcon {
-  max-width: 58px;
-  max-height: 56px;
+  width: 58px;
+  height: 56px;
 }
 
 .story {


### PR DESCRIPTION
The logo was not aligned on any browser that wasn't Firefox.