### PR TITLE
stop loading both mobile and desktop images

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "classnames": "^2.2.6",
     "framer-motion": "^1.6.15",
     "gatsby": "^2.1.18",
-    "gatsby-image": "^2.0.38",
+    "gatsby-image": "^2.2.39",
     "gatsby-plugin-google-analytics": "^2.0.18",
     "gatsby-plugin-manifest": "^2.0.19",
     "gatsby-plugin-postcss": "^2.0.7",

--- a/src/components/home/about_section/team_subsection/member.js
+++ b/src/components/home/about_section/team_subsection/member.js
@@ -2,7 +2,6 @@ import React from "react"
 import PropTypes from "prop-types"
 import Img from "gatsby-image"
 import _ from "lodash"
-import classNames from "classnames"
 
 import SocialLink from "../../../SocialLink"
 import Text from "../../../text"
@@ -11,12 +10,16 @@ import styles from "./member.module.css"
 
 const Member = ({ name, role, social, photo }) => (
   <div className={styles.root}>
-    <div className={classNames(styles.photo, styles.horizontal)}>
-      <Img fadeIn fluid={photo.horizontal.childImageSharp.fluid} />
-    </div>
-    <div className={classNames(styles.photo, styles.vertical)}>
-      <Img fadeIn fluid={photo.vertical.childImageSharp.fluid} />
-    </div>
+    <Img
+      fadeIn
+      fluid={[
+        photo.horizontal.childImageSharp.fluid,
+        {
+          ...photo.vertical.childImageSharp.fluid,
+          media: "(min-width: 768px)",
+        },
+      ]}
+    />
     <div className={styles.info}>
       <div className={styles.name}>
         <Text color="white" bold>

--- a/src/components/home/about_section/team_subsection/member.js
+++ b/src/components/home/about_section/team_subsection/member.js
@@ -15,7 +15,7 @@ const Member = ({ name, role, social, photo }) => (
       fluid={[
         {
           ...photo.horizontal.childImageSharp.fluid,
-          media: "(max-width: 768px)",
+          media: "(max-width: 767px)",
         },
         {
           ...photo.vertical.childImageSharp.fluid,

--- a/src/components/home/about_section/team_subsection/member.js
+++ b/src/components/home/about_section/team_subsection/member.js
@@ -2,6 +2,7 @@ import React from "react"
 import PropTypes from "prop-types"
 import Img from "gatsby-image"
 import _ from "lodash"
+import classNames from "classnames"
 
 import SocialLink from "../../../SocialLink"
 import Text from "../../../text"
@@ -10,16 +11,18 @@ import styles from "./member.module.css"
 
 const Member = ({ name, role, social, photo }) => (
   <div className={styles.root}>
-    <Img
-      fadeIn
-      fluid={[
-        photo.vertical.childImageSharp.fluid,
-        {
-          ...photo.horizontal.childImageSharp.fluid,
-          media: "(min-width: 768px)",
-        },
-      ]}
-    />
+    <div className={styles.photo}>
+      <Img
+        fadeIn
+        fluid={[
+          photo.horizontal.childImageSharp.fluid,
+          {
+            ...photo.vertical.childImageSharp.fluid,
+            media: "(min-width: 768px)",
+          },
+        ]}
+      />
+    </div>
     <div className={styles.info}>
       <div className={styles.name}>
         <Text color="white" bold>

--- a/src/components/home/about_section/team_subsection/member.js
+++ b/src/components/home/about_section/team_subsection/member.js
@@ -13,9 +13,9 @@ const Member = ({ name, role, social, photo }) => (
     <Img
       fadeIn
       fluid={[
-        photo.horizontal.childImageSharp.fluid,
+        photo.vertical.childImageSharp.fluid,
         {
-          ...photo.vertical.childImageSharp.fluid,
+          ...photo.horizontal.childImageSharp.fluid,
           media: "(min-width: 768px)",
         },
       ]}

--- a/src/components/home/about_section/team_subsection/member.js
+++ b/src/components/home/about_section/team_subsection/member.js
@@ -2,7 +2,6 @@ import React from "react"
 import PropTypes from "prop-types"
 import Img from "gatsby-image"
 import _ from "lodash"
-import classNames from "classnames"
 
 import SocialLink from "../../../SocialLink"
 import Text from "../../../text"
@@ -11,18 +10,19 @@ import styles from "./member.module.css"
 
 const Member = ({ name, role, social, photo }) => (
   <div className={styles.root}>
-    <div className={styles.photo}>
-      <Img
-        fadeIn
-        fluid={[
-          photo.horizontal.childImageSharp.fluid,
-          {
-            ...photo.vertical.childImageSharp.fluid,
-            media: "(min-width: 768px)",
-          },
-        ]}
-      />
-    </div>
+    <Img
+      fadeIn
+      fluid={[
+        {
+          ...photo.horizontal.childImageSharp.fluid,
+          media: "(max-width: 768px)",
+        },
+        {
+          ...photo.vertical.childImageSharp.fluid,
+          media: "(min-width: 768px)",
+        },
+      ]}
+    />
     <div className={styles.info}>
       <div className={styles.name}>
         <Text color="white" bold>

--- a/src/components/home/about_section/team_subsection/member.module.css
+++ b/src/components/home/about_section/team_subsection/member.module.css
@@ -22,18 +22,6 @@
   margin-right: 28px;
 }
 
-@media (max-width: 768px) {
-  .vertical {
-    display: none;
-  }
-}
-
-@media (min-width: 768px) {
-  .horizontal {
-    display: none;
-  }
-}
-
 @media (min-width: 950px) {
   .root {
     grid-row-gap: 28px;

--- a/src/components/home/hero_section.js
+++ b/src/components/home/hero_section.js
@@ -27,7 +27,10 @@ const ParallaxImage = ({
                 fadeIn={false}
                 onLoad={onLoad}
                 fluid={[
-                  mobileImage,
+                  {
+                    ...mobileImage,
+                    media: "(max-width: 399px)",
+                  },
                   {
                     ...desktopImage,
                     media: "(min-width: 400px)",

--- a/src/components/home/hero_section.js
+++ b/src/components/home/hero_section.js
@@ -11,7 +11,12 @@ import Title from "./hero_section/title"
 
 import styles from "./hero_section.module.css"
 
-const renderParallaxImage = ({ baseDelay, image, parallaxAmount }) => (
+const ParallaxImage = ({
+  baseDelay,
+  mobileImage,
+  desktopImage,
+  parallaxAmount,
+}) => (
   <ParallaxBanner
     layers={[
       {
@@ -21,7 +26,13 @@ const renderParallaxImage = ({ baseDelay, image, parallaxAmount }) => (
               <Img
                 fadeIn={false}
                 onLoad={onLoad}
-                fluid={image}
+                fluid={[
+                  mobileImage,
+                  {
+                    ...desktopImage,
+                    media: "(min-width: 400px)",
+                  },
+                ]}
                 imgStyle={{ display: "block" }}
                 style={{ height: "100%" }}
               />
@@ -74,51 +85,33 @@ const HeroSection = ({ data, planetMorph, hidePlanet }) => {
             </div>
             <div className={styles.images}>
               <div className={styles.image}>
-                <div className={styles.horizontal}>
-                  {renderParallaxImage({
-                    baseDelay,
-                    image: data.hero1_h.childImageSharp.fluid,
-                    parallaxAmount: 0.2,
-                  })}
-                </div>
-                <div className={styles.vertical}>
-                  {renderParallaxImage({
-                    baseDelay,
-                    image: data.hero1_v.childImageSharp.fluid,
-                    parallaxAmount: 0.2,
-                  })}
+                <div className={styles.inside}>
+                  <ParallaxImage
+                    baseDelay={baseDelay}
+                    mobileImage={data.hero1_h.childImageSharp.fluid}
+                    desktopImage={data.hero1_v.childImageSharp.fluid}
+                    parallaxAmount={0.2}
+                  />
                 </div>
               </div>
               <div className={styles.image}>
-                <div className={styles.horizontal}>
-                  {renderParallaxImage({
-                    baseDelay: baseDelay + 0.1,
-                    image: data.hero2_h.childImageSharp.fluid,
-                    parallaxAmount: 0.2,
-                  })}
-                </div>
-                <div className={styles.vertical}>
-                  {renderParallaxImage({
-                    baseDelay: baseDelay + 0.1,
-                    image: data.hero2_v.childImageSharp.fluid,
-                    parallaxAmount: 0.2,
-                  })}
+                <div className={styles.inside}>
+                  <ParallaxImage
+                    baseDelay={baseDelay + 0.1}
+                    mobileImage={data.hero2_h.childImageSharp.fluid}
+                    desktopImage={data.hero2_v.childImageSharp.fluid}
+                    parallaxAmount={0.2}
+                  />
                 </div>
               </div>
               <div className={styles.image}>
-                <div className={styles.horizontal}>
-                  {renderParallaxImage({
-                    baseDelay: baseDelay + 0.2,
-                    image: data.hero3_h.childImageSharp.fluid,
-                    parallaxAmount: 0.2,
-                  })}
-                </div>
-                <div className={styles.vertical}>
-                  {renderParallaxImage({
-                    baseDelay: baseDelay + 0.2,
-                    image: data.hero3_v.childImageSharp.fluid,
-                    parallaxAmount: 0.2,
-                  })}
+                <div className={styles.inside}>
+                  <ParallaxImage
+                    baseDelay={baseDelay + 0.2}
+                    mobileImage={data.hero3_h.childImageSharp.fluid}
+                    desktopImage={data.hero3_v.childImageSharp.fluid}
+                    parallaxAmount={0.2}
+                  />
                 </div>
               </div>
             </div>
@@ -172,7 +165,7 @@ const query = graphql`
 
     hero3_v: file(relativePath: { regex: "/hero-3-vertical.jpg/" }) {
       childImageSharp {
-        fluid(maxHeight: 452, quality: 95) {
+        fluid(maxHeight: 452, quality: 90) {
           ...GatsbyImageSharpFluid_noBase64
         }
       }

--- a/src/components/home/hero_section.js
+++ b/src/components/home/hero_section.js
@@ -165,7 +165,7 @@ const query = graphql`
 
     hero3_v: file(relativePath: { regex: "/hero-3-vertical.jpg/" }) {
       childImageSharp {
-        fluid(maxHeight: 452, quality: 90) {
+        fluid(maxHeight: 452, quality: 85) {
           ...GatsbyImageSharpFluid_noBase64
         }
       }

--- a/src/components/home/hero_section.module.css
+++ b/src/components/home/hero_section.module.css
@@ -33,8 +33,7 @@
   overflow-y: hidden;
 }
 
-.horizontal,
-.vertical {
+.inside {
   position: absolute;
   top: 50%;
 
@@ -49,12 +48,6 @@
   }
 }
 
-@media (max-width: 399px) {
-  .vertical {
-    display: none;
-  }
-}
-
 @media (min-width: 400px) {
   .images {
     grid-column-gap: 20px;
@@ -66,11 +59,7 @@
     grid-column: 1 / span 2;
   }
 
-  .horizontal {
-    display: none;
-  }
-
-  .vertical {
+  .inside {
     height: 100%;
   }
 }
@@ -108,7 +97,7 @@
     grid-column: 3 / span 2;
   }
 
-  .vertical {
+  .inside {
     position: initial;
     top: initial;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -742,6 +742,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.7.6":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
+  integrity sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.7.0":
   version "7.7.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.7.0.tgz#4fadc1b8e734d97f56de39c77de76f2562e597d0"
@@ -5459,12 +5466,12 @@ gatsby-graphiql-explorer@^0.2.26:
   dependencies:
     "@babel/runtime" "^7.6.3"
 
-gatsby-image@^2.0.38:
-  version "2.2.30"
-  resolved "https://registry.yarnpkg.com/gatsby-image/-/gatsby-image-2.2.30.tgz#3ca58adb1814a759dcaf26d742ae90e89c7144de"
-  integrity sha512-WANouedEFeqLsaDwZbTHlYKTPqV0Htr2A1BiP921SVaR3GrMwtuBoBzpDSXHF+0q9TE2w885gKdNIG/GgzgKaQ==
+gatsby-image@^2.2.39:
+  version "2.2.39"
+  resolved "https://registry.yarnpkg.com/gatsby-image/-/gatsby-image-2.2.39.tgz#c2982152923409139b03446c58fbaa99c15e47a2"
+  integrity sha512-ypb5J+ACeHoGhyw//O0ye7z8sm8yW/MVqpuZ+gkCyXWt3zexp4jjHqV3uDOkvI9fPQC/QCZLXepE7Ve77iAeEg==
   dependencies:
-    "@babel/runtime" "^7.6.3"
+    "@babel/runtime" "^7.7.6"
     object-fit-images "^3.2.4"
     prop-types "^15.7.2"
 


### PR DESCRIPTION
in some places, we use different images between mobile and desktop.
it's not just a matter of the images having a different size, they
also have different "cuts". because the images are loaded async with JavaScript, the CSS rules that add
'display: none' to mobile images in desktop (and the other way around)
are ignored. this means that desktop and mobile images are always loaded for every request.

to solve this, there's a thing called [art
direction](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images#Art_direction)
that [gatsby also supports](https://www.gatsbyjs.org/packages/gatsby-image/#art-directing-multiple-images).

extra: reduced the quality of hero-3 in desktop because it's the biggest
image in our website and it doesn't seem to change its final quality.