### PR TITLE
Optimize the imports of lodash

### DIFF
--- a/src/components/home/about_section/team_subsection/member.js
+++ b/src/components/home/about_section/team_subsection/member.js
@@ -1,7 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
 import Img from "gatsby-image"
-import _ from "lodash"
 
 import SocialLink from "../../../SocialLink"
 import Text from "../../../text"
@@ -34,12 +33,16 @@ const Member = ({ name, role, social, photo }) => (
       </div>
     </div>
     <ul aria-label="Social Links" className={styles.links}>
-      {_.map(social, (url, platform) => {
-        if (!url) return null
+      {Object.keys(social).map(platform => {
+        if (!social[platform]) return null
 
         return (
           <li key={platform} className={styles.link}>
-            <SocialLink name={name} platform={platform} url={url} />
+            <SocialLink
+              name={name}
+              platform={platform}
+              url={social[platform]}
+            />
           </li>
         )
       })}

--- a/src/components/layout/footer/social_links.js
+++ b/src/components/layout/footer/social_links.js
@@ -1,4 +1,3 @@
-import _ from "lodash"
 import React from "react"
 
 import SocialLink from "../../SocialLink"
@@ -19,12 +18,12 @@ const socialDetails = {
 
 const SocialLinks = () => (
   <ul className={styles.root}>
-    {_.map(socialDetails, (url, platform) => (
+    {Object.keys(socialDetails).map(platform => (
       <li key={platform} className={styles.item}>
         <SocialLink
           name="Subvisual"
           platform={platform}
-          url={url}
+          url={socialDetails[platform]}
           size="small"
         />
       </li>


### PR DESCRIPTION
Importing lodash usign `import _ from "lodash"` will import the whole
library. The correct way to import lodash is to only import the pieces
you need, for instance `import map from lodash/map`. In this case, we
simply don't need lodash in this situation, so I removed it. It's still
being used in other places, but this already removes around 70kb to the
bundle size. And because this is JS and our initial animation
requires JS to run, we can use as many optimizations as we can.