### PR TITLE
Inject logo into header component

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -2,17 +2,18 @@ import React from "react"
 import PropTypes from "prop-types"
 import Helmet from "react-helmet"
 
+import Logo from "./logo"
 import Header from "./layout/header"
 import Footer from "./layout/footer"
 
 import styles from "./layout.module.css"
 
-const Layout = ({ children }) => (
+const Layout = ({ children, renderHeaderLogo }) => (
   <div className={styles.root}>
     <Helmet>
       <link rel="stylesheet" href="https://use.typekit.net/bcx8qfd.css" />
     </Helmet>
-    <Header />
+    <Header renderLogo={renderHeaderLogo} />
     <main>{children}</main>
     <Footer />
   </div>
@@ -20,6 +21,11 @@ const Layout = ({ children }) => (
 
 Layout.propTypes = {
   children: PropTypes.node.isRequired,
+  renderHeaderLogo: PropTypes.func,
+}
+
+Layout.defaultProps = {
+  renderHeaderLogo: () => <Logo />,
 }
 
 export default Layout

--- a/src/components/layout/header.js
+++ b/src/components/layout/header.js
@@ -1,16 +1,14 @@
 import React from "react"
+import PropTypes from "prop-types"
 
 import Link from "../link"
-import Logo from "../logo"
 
 import styles from "./header.module.css"
 
-const Header = () => (
+const Header = ({ renderLogo }) => (
   <header className={styles.root}>
     <div className={styles.content}>
-      <div className={styles.logo}>
-        <Logo />
-      </div>
+      <div className={styles.logo}>{renderLogo()}</div>
       <nav>
         <ul className={styles.links}>
           <li className={styles.linkItem}>
@@ -38,5 +36,9 @@ const Header = () => (
     </div>
   </header>
 )
+
+Header.propTypes = {
+  renderLogo: PropTypes.func.isRequired,
+}
 
 export default Header


### PR DESCRIPTION
Why:

* The blog will use a slightly different logo in the header, otherwise
  it should be the same header.

This change addresses the need by:

* Refactoring the layout header component to accept a function that
  renders the logo;
* Refactoring the layout component to accept a function that renders the
  header logo, falling back to the default logo component.