### PR TITLE
Change links to use current text color

### DIFF
--- a/src/components/SocialLink.js
+++ b/src/components/SocialLink.js
@@ -50,7 +50,6 @@ const SocialLink = ({ name: userName, platform, size, url }) => {
       to={url}
       title={`${userName} on ${platformName}`}
       size={size}
-      color="white"
       blank
       faded
     >

--- a/src/components/home/about_section.module.css
+++ b/src/components/home/about_section.module.css
@@ -29,6 +29,8 @@
   max-width: 1184px;
   margin-right: auto;
   margin-left: auto;
+
+  color: #fcfcfc;
 }
 
 .header {

--- a/src/components/layout/footer/location.js
+++ b/src/components/layout/footer/location.js
@@ -39,12 +39,12 @@ const Location = ({ align, geoUrl, image, mapsUrl, name }) => (
         </Text>
       </span>
       <span className={styles.mobile}>
-        <Link to={geoUrl} size="small" color="white" blank faded>
+        <Link to={geoUrl} size="small" blank faded>
           Directions
         </Link>
       </span>
       <span className={styles.desktop}>
-        <Link to={mapsUrl} size="small" color="white" blank faded>
+        <Link to={mapsUrl} size="small" blank faded>
           Directions
         </Link>
       </span>

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -5,8 +5,8 @@ import classNames from "classnames"
 
 import styles from "./link.module.css"
 
-const Link = ({ blank, children, color, faded, internal, size, title, to }) => {
-  const className = classNames(styles.root, styles[size], styles[color], {
+const Link = ({ blank, children, faded, internal, size, title, to }) => {
+  const className = classNames(styles.root, styles[size], {
     [styles.faded]: faded,
   })
 
@@ -36,7 +36,6 @@ const Link = ({ blank, children, color, faded, internal, size, title, to }) => {
 
 Link.propTypes = {
   blank: PropTypes.bool,
-  color: PropTypes.string,
   faded: PropTypes.bool,
   internal: PropTypes.bool,
   size: PropTypes.string,
@@ -46,7 +45,6 @@ Link.propTypes = {
 
 Link.defaultProps = {
   blank: false,
-  color: "black",
   faded: false,
   internal: false,
   size: "regular",

--- a/src/components/link.module.css
+++ b/src/components/link.module.css
@@ -1,4 +1,5 @@
 .root {
+  color: currentColor;
   cursor: pointer;
   opacity: 1;
 
@@ -21,14 +22,6 @@
 
 .root.faded:hover {
   opacity: 1;
-}
-
-.root.black {
-  color: #402f4c;
-}
-
-.root.white {
-  color: #fcfcfc;
 }
 
 .root.small {


### PR DESCRIPTION
Why:

* Links are currently defaulting to the "black" color, and are changed
  using a component property. However their color is based on the
  background, which is set by parent components. So we can instead make
  links depend on text color, which is set by the same components that
  change the background.

This change addresses the issue by:

* Refactoring the link component to always use the current color;
* Refactoring the about subsection component to set the current text
  color accordingly.