### PR TITLE
Change text component to inherit color by default

### DIFF
--- a/src/components/home/about_section.js
+++ b/src/components/home/about_section.js
@@ -31,7 +31,7 @@ const AboutSection = ({ planetMorph }) => (
             </SubsectionTitle>
           </div>
           <p className={styles.text}>
-            <Text color="white">
+            <Text>
               By putting people first and never compromising on quality, we were
               able to shape a team culture that will embrace you and your ideas.
             </Text>
@@ -42,7 +42,7 @@ const AboutSection = ({ planetMorph }) => (
             <SubsectionTitle color="white">And grew with craft</SubsectionTitle>
           </div>
           <p className={styles.text}>
-            <Text color="white">
+            <Text>
               We&apos;ll challenge you to think further and help you do the
               heavy lifting of shaping your product&apos;s development.
             </Text>

--- a/src/components/home/about_section/team_subsection/member.js
+++ b/src/components/home/about_section/team_subsection/member.js
@@ -26,12 +26,10 @@ const Member = ({ name, role, social, photo }) => {
       />
       <div className={styles.info}>
         <div className={styles.name}>
-          <Text color="white" bold>
-            {name}
-          </Text>
+          <Text bold>{name}</Text>
         </div>
         <div className={styles.role}>
-          <Text color="white">{role}</Text>
+          <Text>{role}</Text>
         </div>
       </div>
       <ul aria-label="Social Links" className={styles.links}>

--- a/src/components/layout.module.css
+++ b/src/components/layout.module.css
@@ -2,4 +2,6 @@
   overflow: hidden;
 
   background-color: transparent;
+
+  color: #403f4c;
 }

--- a/src/components/layout/footer.js
+++ b/src/components/layout/footer.js
@@ -19,7 +19,7 @@ const Footer = ({ data }) => (
         </div>
         <div className={styles.callToAction}>
           <p>
-            <Text color="white">Ready to bring your ideas to life?</Text>{" "}
+            <Text>Ready to bring your ideas to life?</Text>{" "}
             <CallToAction color="white">Let&apos;s talk.</CallToAction>
           </p>
         </div>
@@ -45,9 +45,7 @@ const Footer = ({ data }) => (
         </div>
         <div className={styles.social}>
           <div className={styles.socialLabel}>
-            <Text size="small" color="white">
-              Follow us
-            </Text>
+            <Text size="small">Follow us</Text>
           </div>
           <SocialLinks />
         </div>

--- a/src/components/layout/footer/location.js
+++ b/src/components/layout/footer/location.js
@@ -34,9 +34,7 @@ const Location = ({ align, geoUrl, image, mapsUrl, name }) => (
     </div>
     <div className={[styles.info, styles[align]].join(" ")}>
       <span className={styles.name}>
-        <Text size="small" color="white">
-          {name}
-        </Text>
+        <Text size="small">{name}</Text>
       </span>
       <span className={styles.mobile}>
         <Link to={geoUrl} size="small" blank faded>

--- a/src/components/text.js
+++ b/src/components/text.js
@@ -20,7 +20,6 @@ Text.propTypes = {
 
 Text.defaultProps = {
   bold: false,
-  color: "black",
   size: "regular",
 }
 

--- a/src/components/text.module.css
+++ b/src/components/text.module.css
@@ -7,16 +7,8 @@
   font-weight: 700;
 }
 
-.root.black {
-  color: #403f4c;
-}
-
 .root.purple {
   color: #2421ab;
-}
-
-.root.white {
-  color: #fcfcfc;
 }
 
 .root.small {


### PR DESCRIPTION
Why:

* We're constantly setting the text component color when it's not black,
  but the default color actually depends on the background, which is set
  by parent components.

This change addresses the need by:

* Refactoring the text component to recognize only the purple color (the
  rest is actually useless at the moment);
* Refactoring the layout component to set the default text color to
  black;
* Refactoring the about and footer sections not to use the color
  property, which is now redundant.