### PR TITLE
Set anchors to use current text color by default

### DIFF
--- a/src/common/reset.css
+++ b/src/common/reset.css
@@ -31,6 +31,14 @@ dd {
   margin: 0;
 }
 
+a,
+a:active,
+a:focus,
+a:link,
+a:visited {
+  color: currentColor;
+}
+
 address {
   font-style: normal;
 }


### PR DESCRIPTION
Why:

* Most browsers set links to blue by default, purple for visited links,
  and ready when links are pressed. We most definitely don't want any of
  this even by default.