### PR TITLE
Add support for inactive team members

### DIFF
--- a/src/components/home/about_section/team_subsection.js
+++ b/src/components/home/about_section/team_subsection.js
@@ -7,7 +7,7 @@ import styles from "./team_subsection.module.css"
 
 const teamQuery = graphql`
   query TeamQuery {
-    allTeamYaml {
+    allTeamYaml(filter: { active: { ne: false } }) {
       edges {
         node {
           id

--- a/src/data/team.yaml
+++ b/src/data/team.yaml
@@ -1,4 +1,7 @@
 ---
+- name: Bruno Azevedo
+  active: false
+
 - name: "Fernando Mendes"
   photo:
     horizontal: "../images/team/fernando-mendes-h.jpg"


### PR DESCRIPTION
Why:

* The blog will need to fetch the information of users from the team
  data file, but this file is currently omitting past blog post authors.
  Ideally the author information should be in the post itself to keep
  things denormalized, but since it isn't, the quickest way to address
  the issue is to re-add old team members, and simply add a field to
  mark them as inactive, excluding them from the team page if so.