### PR TITLE
Set base typography sizes

### DIFF
--- a/src/common/normalize.css
+++ b/src/common/normalize.css
@@ -4,12 +4,18 @@
 
 body {
   overflow-x: hidden;
-}
 
-html,
-body {
   color: #403f4c;
 
   font-family: colfax-web, sans-serif;
+  font-size: 16px;
   font-weight: 400;
+  line-height: 20px;
+}
+
+@media (min-width: 950px) {
+  body {
+    font-size: 20px;
+    line-height: 28px;
+  }
 }


### PR DESCRIPTION
Why:

* The links in the top navigation bar are too small;
* Most of the content of our pages use a base font size and line heights
  for the body of text, and we're gradually changing components that
  simply inherit these values to do just that. The top navigation bar
  was already changed accordingly.