### PR TITLE
Remove blockquote margins and link underlines

### DIFF
--- a/src/common/reset.css
+++ b/src/common/reset.css
@@ -26,7 +26,8 @@ ul,
 li,
 dl,
 dt,
-dd {
+dd,
+blockquote {
   padding: 0;
   margin: 0;
 }
@@ -37,6 +38,8 @@ a:focus,
 a:link,
 a:visited {
   color: currentColor;
+
+  text-decoration: none;
 }
 
 address {


### PR DESCRIPTION
Why:

* Blog posts are written in Markdown, and rendering them won't allow us
  to set specific classes to the DOM elements. Therefore, we need to
  ensure styles are as uniform and sane as possible from the start and
  across browsers.
* By default blockquote elements have some spacing around, which we want
  to remove.
* By default browsers underline active links in some states, which we
  want to remove for consistency.