### PR TITLE
Remove support for inactive team members

### DIFF
--- a/src/components/home/about_section/team_subsection.js
+++ b/src/components/home/about_section/team_subsection.js
@@ -7,7 +7,7 @@ import styles from "./team_subsection.module.css"
 
 const teamQuery = graphql`
   query TeamQuery {
-    allTeamMemberYaml(filter: { active: { ne: false } }) {
+    allTeamMemberYaml {
       edges {
         node {
           id

--- a/src/data/team_member.yaml
+++ b/src/data/team_member.yaml
@@ -1,7 +1,4 @@
 ---
-- name: Bruno Azevedo
-  active: false
-
 - name: "Fernando Mendes"
   photo:
     horizontal: "../images/team/fernando-mendes-h.jpg"


### PR DESCRIPTION
Why:

* Gatsby has a better mechanism for adding the information of blog
  contributors, while keeping the team members file (which requires more
  information) untouched.

This reverts commit b395ea0ac9dbaf782ecdab3c16e173142e495e53 (#236).