### PR TITLE
Add blog contributors data

### DIFF
--- a/src/data/blog_contributor.yaml
+++ b/src/data/blog_contributor.yaml
@@ -1,0 +1,15 @@
+---
+- slug: bruno-azevedo
+  name: Bruno Azevedo
+  bio: >-
+    Likes to make a difference in everything he does. Music lover and
+    practitioner. Healthy Hacker wannabe.
+  social:
+    github: azevedo-252
+    twitter: azevedo_252
+
+- slug: summer-campers
+  name: Summer Campers
+  bio: >-
+    Thirsty for knowledge and keen to learn. Then we found out they had free
+    beer.


### PR DESCRIPTION
Why:

* Some blog post authors are no longer on the team, some were just
  guests.