### PR TITLE
Add wrapper components for the blog posts

### DIFF
--- a/src/components/blog/post/body_wrapper.js
+++ b/src/components/blog/post/body_wrapper.js
@@ -1,0 +1,18 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+import BlogPostWrapper from "./wrapper"
+
+import styles from "./body_wrapper.module.css"
+
+const BlogPostBodyWrapper = ({ children }) => (
+  <BlogPostWrapper>
+    <div className={styles.content}>{children}</div>
+  </BlogPostWrapper>
+)
+
+BlogPostBodyWrapper.propTypes = {
+  children: PropTypes.node.isRequired,
+}
+
+export default BlogPostBodyWrapper

--- a/src/components/blog/post/body_wrapper.module.css
+++ b/src/components/blog/post/body_wrapper.module.css
@@ -1,0 +1,10 @@
+.content {
+  max-width: 762px;
+  margin-left: auto;
+}
+
+@media (min-width: 950px) {
+  .content {
+    max-width: 834px;
+  }
+}

--- a/src/components/blog/post/wrapper.js
+++ b/src/components/blog/post/wrapper.js
@@ -1,0 +1,23 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+import PageWideWrapper from "../../page_wide_wrapper"
+
+import styles from "./wrapper.module.css"
+
+const BlogPostWrapper = ({ children, padded }) => (
+  <PageWideWrapper {...{ padded }}>
+    <div className={styles.content}>{children}</div>
+  </PageWideWrapper>
+)
+
+BlogPostWrapper.propTypes = {
+  children: PropTypes.node.isRequired,
+  padded: PropTypes.bool,
+}
+
+BlogPostWrapper.defaultProps = {
+  padded: false,
+}
+
+export default BlogPostWrapper

--- a/src/components/blog/post/wrapper.module.css
+++ b/src/components/blog/post/wrapper.module.css
@@ -1,0 +1,4 @@
+.content {
+  max-width: 980px;
+  margin-right: auto;
+}

--- a/src/components/page_wide_wrapper.js
+++ b/src/components/page_wide_wrapper.js
@@ -1,0 +1,28 @@
+import React from "react"
+import PropTypes from "prop-types"
+import classNames from "classnames"
+
+import styles from "./page_wide_wrapper.module.css"
+
+const PageWideWrapper = ({ children, padded }) => {
+  const className = classNames(styles.root, {
+    [styles.padded]: padded,
+  })
+
+  return (
+    <div className={className}>
+      <div className={styles.content}>{children}</div>
+    </div>
+  )
+}
+
+PageWideWrapper.propTypes = {
+  children: PropTypes.node.isRequired,
+  padded: PropTypes.bool,
+}
+
+PageWideWrapper.defaultProps = {
+  padded: false,
+}
+
+export default PageWideWrapper

--- a/src/components/page_wide_wrapper.module.css
+++ b/src/components/page_wide_wrapper.module.css
@@ -1,0 +1,14 @@
+.root.padded {
+  padding: 0 20px;
+}
+
+.content {
+  max-width: 1182px;
+  margin: 0 auto;
+}
+
+@media (min-width: 950px) {
+  .root.padded {
+    padding: 0 28px;
+  }
+}


### PR DESCRIPTION
Why:

* The layout of the blog is a tricky one with 3 levels.

  On the outer the content is centered with a limit to the maximum width of the design. This may or may not be padded (for instance images have to fill the entire width without side padding in mobile).

  Below that level is the post content, including header and body, which has a smaller limit width and is aligned to the left inside the outer container.

  Lastly, there's the body of the post, which is aligned to the right within the post container, also with a smaller width.

  These containers allow the layout to responsively adapt to the entire range of widths from mobile to desktop, only causing a jump when font sizes and padding sizes have to change.

![Screenshot_2020-03-20 https deploy-preview-212--subvisual netlify com](https://user-images.githubusercontent.com/1141870/77177867-2678c180-6abe-11ea-8424-26591464a569.jpg)