### PR TITLE
Simplify GraphQL schema

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,28 +1,16 @@
-const defaultTo = require("lodash/defaultTo")
-
-exports.createSchemaCustomization = ({ actions, schema }) => {
+exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions
   const typeDefs = [
-    schema.buildObjectType({
-      name: "TeamMemberYaml",
-      interfaces: ["Node"],
-      extensions: {
-        infer: false,
-      },
-      fields: {
-        id: "String!",
-        name: "String!",
-        photo: "Photo!",
-        role: "String!",
-        bio: "String",
-        social: "Social",
-        active: {
-          type: "Boolean",
-          resolve: ({ active }) => defaultTo(active, true),
-        },
-      },
-    }),
     `
+      type TeamMemberYaml implements Node @dontInfer {
+        key: String!,
+        name: String!,
+        photo: Photo!,
+        role: String!,
+        bio: String,
+        social: Social,
+      }
+
       type Photo {
         horizontal: File! @fileByRelativePath,
         vertical: File! @fileByRelativePath,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -2,15 +2,6 @@ exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions
   const typeDefs = [
     `
-      type TeamMemberYaml implements Node @dontInfer {
-        key: String!,
-        name: String!,
-        photo: Photo!,
-        role: String!,
-        bio: String,
-        social: Social,
-      }
-
       type Photo {
         horizontal: File! @fileByRelativePath,
         vertical: File! @fileByRelativePath,
@@ -24,6 +15,15 @@ exports.createSchemaCustomization = ({ actions }) => {
         medium: String,
         twitter: String,
         web: String,
+      }
+
+      type TeamMemberYaml implements Node @dontInfer {
+        key: String!,
+        name: String!,
+        photo: Photo!,
+        role: String!,
+        bio: String,
+        social: Social,
       }
 
       type VentureYaml implements Node @dontInfer {


### PR DESCRIPTION
Why:

* #251 removed the active field from team members, which required
  creating a type via JavaScript API to set the default value. Which we
  don't need anymore.