### PR TITLE
Add blog post body component

### DIFF
--- a/src/components/blog/post/body.js
+++ b/src/components/blog/post/body.js
@@ -7,9 +7,8 @@ import styles from "./body.module.scss"
 
 const PostBody = ({ html }) => (
   <BodyWrapper>
-    {/* eslint-disable react/no-danger */}
+    {/* eslint-disable-next-line react/no-danger */}
     <div className={styles.root} dangerouslySetInnerHTML={{ __html: html }} />
-    {/* eslint-enable react/no-danger */}
   </BodyWrapper>
 )
 

--- a/src/components/blog/post/body.js
+++ b/src/components/blog/post/body.js
@@ -1,0 +1,20 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+import BodyWrapper from "./body_wrapper"
+
+import styles from "./body.module.scss"
+
+const PostBody = ({ html }) => (
+  <BodyWrapper>
+    {/* eslint-disable react/no-danger */}
+    <div className={styles.root} dangerouslySetInnerHTML={{ __html: html }} />
+    {/* eslint-enable react/no-danger */}
+  </BodyWrapper>
+)
+
+PostBody.propTypes = {
+  html: PropTypes.string.isRequired,
+}
+
+export default PostBody

--- a/src/components/blog/post/body.module.scss
+++ b/src/components/blog/post/body.module.scss
@@ -1,14 +1,4 @@
 .root {
-  font-family: "Acta", serif;
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 28px;
-
-  @media (--desktop) {
-    font-size: 20px;
-    line-height: 32px;
-  }
-
   @import './body/anchor';
   @import './body/blockquote';
   @import './body/bold';
@@ -20,6 +10,16 @@
   @import './body/italic';
   @import './body/list';
   @import './body/paragraph';
+
+  font-family: "Acta", serif;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 28px;
+
+  @media (--desktop) {
+    font-size: 20px;
+    line-height: 32px;
+  }
 
   /* Drop cap */
 

--- a/src/components/blog/post/body.module.scss
+++ b/src/components/blog/post/body.module.scss
@@ -1,0 +1,46 @@
+.root {
+  font-family: "Acta", serif;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 28px;
+
+  @media (--desktop) {
+    font-size: 20px;
+    line-height: 32px;
+  }
+
+  @import './body/anchor';
+  @import './body/blockquote';
+  @import './body/bold';
+  @import './body/code';
+  @import './body/code_block';
+  @import './body/heading';
+  @import './body/horizontal_rule';
+  @import './body/image';
+  @import './body/italic';
+  @import './body/list';
+  @import './body/paragraph';
+
+  /* Drop cap */
+
+  & > p:first-child::first-letter {
+    float: left;
+    padding-right: 4px;
+    margin-top: 0;
+
+    font-family: "Acta Display", serif;
+    font-size: 56px;
+    line-height: 56px;
+
+    @media (--desktop) {
+      margin-top: -2px;
+
+      font-size: 66px;
+      line-height: 66px;
+    }
+
+    @-moz-document url-prefix() {
+      margin-top: 8px;
+    }
+  }
+}

--- a/src/components/blog/post/body/_anchor.scss
+++ b/src/components/blog/post/body/_anchor.scss
@@ -1,0 +1,17 @@
+a {
+  &,
+  &:hover,
+  &:link,
+  &:visited {
+    color: #2421ab;
+
+    font-weight: 700;
+    text-decoration: none;
+  }
+
+  &:hover {
+    opacity: 0.5;
+
+    transition: opacity 0.2s;
+  }
+}

--- a/src/components/blog/post/body/_blockquote.scss
+++ b/src/components/blog/post/body/_blockquote.scss
@@ -1,0 +1,76 @@
+blockquote {
+  position: relative;
+
+  max-width: 618px;
+  padding: 20px 20px 0;
+  margin: 56px auto 40px 0;
+
+  font-family: 'Acta Headline', serif;
+  font-size: 20px;
+  font-weight: 800;
+  line-height: 28px;
+
+  @media (--desktop) {
+    max-width: 634px;
+    padding: 28px 28px 0 28px;
+    margin: 78px auto 56px 0;
+
+    font-size: 28px;
+    line-height: 40px;
+  }
+
+  /**
+   * Fix for Firefox font rendering issues.
+   */
+  @-moz-document url-prefix() {
+    font-weight: lighter;
+  }
+
+  &::before {
+    content: '“';
+
+    position: absolute;
+    top: -26px;
+    left: 95px;
+
+    display: inline-block;
+
+    font-size: 56px;
+    font-weight: normal;
+    line-height: 56px;
+
+    @media (--desktop) {
+      top: -34px;
+      left: 128px;
+
+      font-size: 72px;
+      line-height: 72px;
+    }
+  }
+
+  p {
+    padding: 0;
+  }
+
+  p:not(:last-child) {
+    margin-bottom: 20px;
+  }
+
+  p:last-child:not(:first-child) {
+    width: calc(100% - 72px);
+    max-width: 506px;
+    margin-left: auto;
+
+    font-family: colfax-web, sans-serif;
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 20px;
+
+    @media (--desktop) {
+      max-width: 478px;
+
+      font-size: 20px;
+      line-height: 28px;
+    }
+  }
+}

--- a/src/components/blog/post/body/_bold.scss
+++ b/src/components/blog/post/body/_bold.scss
@@ -1,0 +1,3 @@
+strong {
+  font-weight: bold;
+}

--- a/src/components/blog/post/body/_code.scss
+++ b/src/components/blog/post/body/_code.scss
@@ -1,0 +1,4 @@
+code {
+  font-family: source-code-pro, monospace;
+  font-weight: 400;
+}

--- a/src/components/blog/post/body/_code_block.scss
+++ b/src/components/blog/post/body/_code_block.scss
@@ -1,0 +1,26 @@
+pre {
+  padding: 20px;
+  margin: 20px 0;
+
+  background-color: rgba(64, 63, 76, .1);
+
+  @media (--desktop) {
+    padding: 28px;
+    margin: 28px 0;
+
+    font-size: 20px;
+    line-height: 28px;
+  }
+
+  & > code {
+    display: block;
+    max-width: 578px;
+    padding: 0;
+    margin: 0 auto;
+
+    background-color: transparent;
+    border-radius: 0;
+
+    white-space: break-spaces;
+  }
+}

--- a/src/components/blog/post/body/_heading.scss
+++ b/src/components/blog/post/body/_heading.scss
@@ -1,0 +1,54 @@
+h1 {
+  display: none;
+}
+
+h2,
+h3,
+h4,
+h5,
+h6 {
+  max-width: 618px;
+  padding: 0 20px;
+
+  font-family: colfax-web, sans-serif;
+  font-weight: 500;
+
+  @media (--desktop) {
+    max-width: 634px;
+    padding: 0 28px;
+  }
+}
+
+h2 {
+  margin: 84px auto 20px;
+
+  font-size: 20px;
+  line-height: 28px;
+
+  @media (--desktop) {
+    margin: 112px auto 28px;
+
+    font-size: 40px;
+    line-height: 56px;
+  }
+}
+
+h3 {
+  margin: 40px auto 20px;
+
+  font-size: 20px;
+  line-height: 28px;
+
+  @media (--desktop) {
+    margin: 56px auto 28px;
+
+    font-size: 28px;
+    line-height: 40px;
+  }
+}
+
+h4,
+h5,
+h6 {
+  margin: 0 auto;
+}

--- a/src/components/blog/post/body/_horizontal_rule.scss
+++ b/src/components/blog/post/body/_horizontal_rule.scss
@@ -1,0 +1,12 @@
+hr {
+  width: 25vw;
+  max-width: 174px;
+  margin: 28px auto;
+
+  border-top: none;
+  border-bottom: currentColor solid 1px;
+
+  @media (--desktop) {
+    margin: 56px auto;
+  }
+}

--- a/src/components/blog/post/body/_image.scss
+++ b/src/components/blog/post/body/_image.scss
@@ -1,0 +1,15 @@
+img {
+  position: relative;
+  left: 50%;
+
+  display: block;
+  width: auto;
+  max-width: 100%;
+  margin: 40px 0;
+
+  transform: translateX(-50%);
+
+  @media (--desktop) {
+    margin: 56px 0;
+  }
+}

--- a/src/components/blog/post/body/_inline_code.scss
+++ b/src/components/blog/post/body/_inline_code.scss
@@ -1,0 +1,7 @@
+code {
+  padding: 0 4px;
+
+  background-color: rgba(64, 63, 76, .1);
+
+  font-size: smaller;
+}

--- a/src/components/blog/post/body/_italic.scss
+++ b/src/components/blog/post/body/_italic.scss
@@ -1,0 +1,3 @@
+em {
+  font-style: italic;
+}

--- a/src/components/blog/post/body/_list.scss
+++ b/src/components/blog/post/body/_list.scss
@@ -1,0 +1,16 @@
+ol,
+ul {
+  max-width: 618px;
+  padding: 0 20px 0 40px;
+  margin: 20px auto;
+
+  @media (--desktop) {
+    max-width: 634px;
+    padding: 0 28px 0 56px;
+    margin: 28px auto;
+  }
+}
+
+li {
+  @import './inline_code';
+}

--- a/src/components/blog/post/body/_paragraph.scss
+++ b/src/components/blog/post/body/_paragraph.scss
@@ -1,0 +1,21 @@
+p {
+  max-width: 618px;
+  padding: 0 20px;
+  margin: 20px auto 28px;
+
+  @media (--desktop) {
+    max-width: 634px;
+    padding: 0 28px;
+    margin: 28px auto 32px;
+  }
+
+  p:first-child {
+    margin-top: 0;
+  }
+
+  p:last-child {
+    margin-bottom: 0;
+  }
+
+  @import './inline_code';
+}


### PR DESCRIPTION
Why:

* The body of a blog post will be generated from the respective Markdown
  file. As such, we need to style the generated elements without being
  able to set specific classes to each one.
* There are also many details here that have to tweaked all at once
  since we can't split the inner parts of the Markdown document into
  smaller components, such as spacings, typography, adjustments for
  responsiveness, etc.