### PR TITLE
Add PostCSS plugin for nesting CSS

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,3 +1,6 @@
+const postCssCustomMedia = require(`postcss-custom-media`)
+const postCssNested = require(`postcss-nested`)
+
 module.exports = {
   siteMetadata: {
     title: "Subvisual",
@@ -10,7 +13,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-postcss`,
       options: {
-        postCssPlugins: [require(`postcss-custom-media`)()],
+        postCssPlugins: [postCssCustomMedia(), postCssNested()],
       },
     },
     `gatsby-plugin-react-helmet`,

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "intersection-observer": "0.7.0",
     "lodash": "^4.17.15",
     "popmotion": "^8.6.10",
+    "postcss-nested": "^4.2.1",
     "prop-types": "^15.7.2",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",

--- a/src/components/call_to_action.module.css
+++ b/src/components/call_to_action.module.css
@@ -6,62 +6,60 @@
   font-family: colfax-web, sans-serif;
   font-weight: 700;
   text-decoration: none;
-}
 
-.root::after {
-  content: '';
+  &::after {
+    content: '';
 
-  position: absolute;
-  bottom: 0;
-  left: 0;
+    position: absolute;
+    bottom: 0;
+    left: 0;
 
-  width: 100%;
+    width: 100%;
 
-  border-bottom: 3px solid currentColor;
+    border-bottom: 3px solid currentColor;
 
-  transform: translateY(1px);
-
-  transition: transform 0.2s;
-}
-
-.root.blue {
-  color: #2421ab;
-}
-
-.root.white {
-  color: #fcfcfc;
-}
-
-.root.regular {
-  font-size: 16px;
-  line-height: 20px;
-}
-
-.root.large {
-  font-size: 20px;
-  line-height: 28px;
-}
-
-.root.large::after {
-  border-bottom-width: 4px;
-}
-
-@media (min-width: 768px) {
-  .root:hover::after {
-    transform: translateY(3px);
+    transform: translateY(1px);
 
     transition: transform 0.2s;
   }
-}
 
-@media (min-width: 950px) {
-  .root.regular {
-    font-size: 20px;
-    line-height: 28px;
+  &:hover::after {
+    @media (min-width: 768px) {
+      transform: translateY(3px);
+
+      transition: transform 0.2s;
+    }
   }
 
-  .root.large {
-    font-size: 28px;
-    line-height: 40px;
+  &.blue {
+    color: #2421ab;
+  }
+
+  &.white {
+    color: #fcfcfc;
+  }
+
+  &.regular {
+    font-size: 16px;
+    line-height: 20px;
+
+    @media (min-width: 950px) {
+      font-size: 20px;
+      line-height: 28px;
+    }
+  }
+
+  &.large {
+    font-size: 20px;
+    line-height: 28px;
+
+    @media (min-width: 950px) {
+      font-size: 28px;
+      line-height: 40px;
+    }
+
+    &::after {
+      border-bottom-width: 4px;
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3583,6 +3583,11 @@ cssesc@^2.0.0:
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-2.0.0.tgz#3b13bd1bb1cb36e1bcb5a4dcd27f54c5dcb35703"
   integrity sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==
 
+cssesc@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
+  integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
 cssnano-preset-default@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz#51ec662ccfca0f88b396dcd9679cdb931be17f76"
@@ -9736,6 +9741,14 @@ postcss-modules-values@^1.3.0:
     icss-replace-symbols "^1.1.0"
     postcss "^6.0.1"
 
+postcss-nested@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/postcss-nested/-/postcss-nested-4.2.1.tgz#4bc2e5b35e3b1e481ff81e23b700da7f82a8b248"
+  integrity sha512-AMayXX8tS0HCp4O4lolp4ygj9wBn32DJWXvG6gCv+ZvJrEa00GUxJcJEEzMh87BIe6FrWdYkpR2cuyqHKrxmXw==
+  dependencies:
+    postcss "^7.0.21"
+    postcss-selector-parser "^6.0.2"
+
 postcss-normalize-charset@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz#8b35add3aee83a136b0471e0d59be58a50285dd4"
@@ -9898,6 +9911,15 @@ postcss-selector-parser@^5.0.0-rc.4:
   integrity sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==
   dependencies:
     cssesc "^2.0.0"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+
+postcss-selector-parser@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz#934cf799d016c83411859e09dcecade01286ec5c"
+  integrity sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==
+  dependencies:
+    cssesc "^3.0.0"
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 


### PR DESCRIPTION
Why:

* The styles for the blog post body (being added in #257) are more
  complex than resonable mostly because, due to the Markdown rendering,
  we're unable to use specific CSS classes for each rendered element,
  and as such have to rely heavily on descendant selectors, which is
  causing a lot of repetition.
* The issue is not specific to the blog though, and as shown with the
  CTA component, this can significantly simplify the styles of some
  components.