### PR TITLE
Extend GraphQL schema for blog

### DIFF
--- a/config/node/create_schema_customization.js
+++ b/config/node/create_schema_customization.js
@@ -2,6 +2,31 @@ module.exports = ({ actions }) => {
   const { createTypes } = actions
   const typeDefs = [
     `
+      interface Author {
+        key: String!,
+        name: String!,
+      }
+
+      type BlogContributorYaml implements Author & Node @dontInfer {
+        key: String!,
+        bio: String,
+        name: String!,
+        social: Social,
+      }
+
+      type Frontmatter {
+        id: Int!,
+        author: Author! @link(by: "key"),
+        date: Date!,
+        path: String!,
+        tags: [String]!,
+        title: String!,
+      }
+
+      type MarkdownRemark implements Node {
+        frontmatter: Frontmatter!,
+      }
+
       type Photo {
         horizontal: File! @fileByRelativePath,
         vertical: File! @fileByRelativePath,
@@ -17,7 +42,7 @@ module.exports = ({ actions }) => {
         web: String,
       }
 
-      type TeamMemberYaml implements Node @dontInfer {
+      type TeamMemberYaml implements Author & Node @dontInfer {
         key: String!,
         name: String!,
         photo: Photo!,


### PR DESCRIPTION
Why:

* For the blog, we'll use the `gatsby-transformer-remark`, processes and
  loads all Markdown files as `MarkdownRemark` nodes.
* From these nodes, we'll need to extract not only the content, which we
  want he system to infer, but also the frontmatter content, which we
  know the structure and can include in the schema.
* One of the fields in the blog post schema is the author. We want the
  author information to come from two distinct sources at the moment:
  the team and the blog contributores, both of which are loaded through
  yaml.

This change addresses the need by:

* Defining the structure of a post's frontmatter using an author
  interface, which both blog contributors and team members have to
  implement in order to correctly render the blog posts with their
  information.
* This has the added advantage that GraphQL will now automatically load
  the author information into the post's author field.