### PR TITLE
Fix mixed content warning in Netlify

### DIFF
--- a/src/pages/blog/posts/132-design-sprints-and-the-academia.md
+++ b/src/pages/blog/posts/132-design-sprints-and-the-academia.md
@@ -86,7 +86,7 @@ it, the process and approach you chose were focal. Besides the grade taking them
 very complex system that wouldn't do what it was supposed
 to.
 
-![Non-working is best working](http://i.imgur.com/t8UHRIY.gif)
+![Non-working is best working](https://i.imgur.com/t8UHRIY.gif)
 
 *A non-working project was as good as
 dead* so the first goal was to have *something* working.

--- a/src/pages/blog/posts/135-super-powered-vim-part-iii-skeletons.md
+++ b/src/pages/blog/posts/135-super-powered-vim-part-iii-skeletons.md
@@ -66,7 +66,7 @@ That command will then call the `skel#InsertSkeleton` function (see the code sni
 
 For the example of `app/models/foo.rb`, this will literally insert the word `class` into the buffer, and call `UltiSnips#ExpandSnippet()` for us, creating the class definition.
 
-![magic](http://i.imgur.com/Efolbol.gif)
+![magic](https://i.imgur.com/Efolbol.gif)
 
 ## But wait, there's more
 


### PR DESCRIPTION
Why:

* When deploying, Netlify is notifying us of insecure mixed content
  being detected in our blog posts:

  ```
  Although you have enabled HTTPS on your site, we’ve detected some content that’s still being served over an HTTP connection. Learn more about mixed content.

    In blog/posts/132-design-sprints-and-the-academia/index.html:

        Insecure img urls:
            http://i.imgur.com/t8UHRIY.gif

    In blog/posts/135-super-powered-vim-part-iii-skeletons/index.html:

        Insecure img urls:
            http://i.imgur.com/Efolbol.gif
  ```