### PR TITLE
Dynamically fill blog posts list

### DIFF
--- a/src/components/blog/posts_list.js
+++ b/src/components/blog/posts_list.js
@@ -43,7 +43,7 @@ const renderItem = ({ fields, frontmatter }) => {
   )
 }
 
-const BlogPostList = () => {
+const BlogPostsList = () => {
   const {
     allMarkdownRemark: { nodes: postsNodes },
   } = useStaticQuery(query)
@@ -57,4 +57,4 @@ const BlogPostList = () => {
   )
 }
 
-export default BlogPostList
+export default BlogPostsList

--- a/src/components/blog/posts_list.js
+++ b/src/components/blog/posts_list.js
@@ -1,23 +1,71 @@
 import React from "react"
+import PropTypes from "prop-types"
+import { StaticQuery, graphql } from "gatsby"
 
 import Entry from "./posts_list/entry"
 
 import styles from "./posts_list.module.scss"
 
-const PostsList = () => (
+const renderItem = ({ id, ...entry }) => (
+  <li key={id} className={styles.postsListItem}>
+    <Entry {...entry} />
+  </li>
+)
+
+const BlogPostsList = ({ items }) => (
   <div className={styles.root}>
     <div className={styles.content}>
-      <ol className={styles.postsList}>
-        <li className={styles.postsListItem}>
-          <Entry
-            author="Subvisual"
-            title="Coming soon..."
-            intro="Our blog is making its return. In style."
-          />
-        </li>
-      </ol>
+      <ol className={styles.postsList}>{items.map(renderItem)}</ol>
     </div>
   </div>
 )
 
-export default PostsList
+BlogPostsList.propTypes = {
+  items: PropTypes.array.isRequired,
+}
+
+const query = graphql`
+  {
+    allMarkdownRemark(sort: { order: DESC, fields: [frontmatter___date] }) {
+      nodes {
+        fields {
+          slug
+        }
+        frontmatter {
+          author {
+            name
+          }
+          date
+          id
+          title
+          intro
+        }
+      }
+    }
+  }
+`
+
+export default () => (
+  <StaticQuery
+    query={query}
+    render={data => {
+      const {
+        allMarkdownRemark: { nodes: postsNodes },
+      } = data
+
+      const items = postsNodes.map(({ fields, frontmatter }) => {
+        const { slug } = fields
+        const { author, ...entry } = frontmatter
+        const { name: authorName } = author
+
+        return {
+          author: authorName,
+          slug,
+          ...entry,
+        }
+      })
+
+      return <BlogPostsList items={items} />
+    }}
+  />
+)

--- a/src/components/blog/posts_list.js
+++ b/src/components/blog/posts_list.js
@@ -1,28 +1,9 @@
 import React from "react"
-import PropTypes from "prop-types"
-import { StaticQuery, graphql } from "gatsby"
+import { useStaticQuery, graphql } from "gatsby"
 
 import Entry from "./posts_list/entry"
 
 import styles from "./posts_list.module.scss"
-
-const renderItem = ({ id, ...entry }) => (
-  <li key={id} className={styles.postsListItem}>
-    <Entry {...entry} />
-  </li>
-)
-
-const BlogPostsList = ({ items }) => (
-  <div className={styles.root}>
-    <div className={styles.content}>
-      <ol className={styles.postsList}>{items.map(renderItem)}</ol>
-    </div>
-  </div>
-)
-
-BlogPostsList.propTypes = {
-  items: PropTypes.array.isRequired,
-}
 
 const query = graphql`
   {
@@ -45,27 +26,35 @@ const query = graphql`
   }
 `
 
-export default () => (
-  <StaticQuery
-    query={query}
-    render={data => {
-      const {
-        allMarkdownRemark: { nodes: postsNodes },
-      } = data
+const renderItem = ({ fields, frontmatter }) => {
+  const { slug } = fields
+  const { author, id, ...entry } = frontmatter
+  const { name: authorName } = author
+  const entryProps = {
+    author: authorName,
+    slug,
+    ...entry,
+  }
 
-      const items = postsNodes.map(({ fields, frontmatter }) => {
-        const { slug } = fields
-        const { author, ...entry } = frontmatter
-        const { name: authorName } = author
+  return (
+    <li key={id} className={styles.postsListItem}>
+      <Entry {...entryProps} />
+    </li>
+  )
+}
 
-        return {
-          author: authorName,
-          slug,
-          ...entry,
-        }
-      })
+const BlogPostList = () => {
+  const {
+    allMarkdownRemark: { nodes: postsNodes },
+  } = useStaticQuery(query)
 
-      return <BlogPostsList items={items} />
-    }}
-  />
-)
+  return (
+    <div className={styles.root}>
+      <div className={styles.content}>
+        <ol className={styles.postsList}>{postsNodes.map(renderItem)}</ol>
+      </div>
+    </div>
+  )
+}
+
+export default BlogPostList

--- a/src/components/blog/posts_list/entry.js
+++ b/src/components/blog/posts_list/entry.js
@@ -1,28 +1,35 @@
 import React from "react"
 import PropTypes from "prop-types"
 import { Link } from "gatsby"
+import dateFormat from "dateformat"
 
 import styles from "./entry.module.scss"
 
-const Entry = ({ author, intro, slug, title }) => (
-  <div className={styles.root}>
-    <Link to={`/blog/${slug}`} className={styles.title}>
-      {title}
-    </Link>
-    <p className={styles.intro}>
-      <Link to={`/blog/${slug}`}>
-        {/* eslint-disable-next-line react/no-danger */}
-        <span dangerouslySetInnerHTML={{ __html: intro }} />
+const Entry = ({ author, date, intro, slug, title }) => {
+  const formattedDate = dateFormat(date, "mmmm d, yyyy")
+
+  return (
+    <div className={styles.root}>
+      <Link to={`/blog/${slug}`} className={styles.title}>
+        {title}
       </Link>
-    </p>
-    <div className={styles.info}>
-      <span className={styles.author}>By {author}</span>
+      <p className={styles.intro}>
+        <Link to={`/blog/${slug}`}>
+          {/* eslint-disable-next-line react/no-danger */}
+          <span dangerouslySetInnerHTML={{ __html: intro }} />
+        </Link>
+      </p>
+      <div className={styles.info}>
+        <span className={styles.author}>By {author}</span>
+        <span className={styles.date}>On {formattedDate}</span>
+      </div>
     </div>
-  </div>
-)
+  )
+}
 
 Entry.propTypes = {
   author: PropTypes.string.isRequired,
+  date: PropTypes.instanceOf(Date).isRequired,
   intro: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
 }


### PR DESCRIPTION
Why:

* Last step before #212, we need to change https://subvisual.com/blog to
  dynamically retrieve the list of posts for which we generated a page.

This change addresses the need by:

* Changing the posts list component to query the contents processed from
  Markdown files;
* Adding a formatted date field to the posts list entry component, along
  with the intro in the frontmatter, and the author information.