### PR TITLE
Fix iframe in blog posts body

### DIFF
--- a/src/components/blog/post/body.module.scss
+++ b/src/components/blog/post/body.module.scss
@@ -6,6 +6,7 @@
   @import "./body/code_block";
   @import "./body/heading";
   @import "./body/horizontal_rule";
+  @import "./body/iframe";
   @import "./body/image";
   @import "./body/italic";
   @import "./body/list";

--- a/src/components/blog/post/body/_iframe.scss
+++ b/src/components/blog/post/body/_iframe.scss
@@ -1,0 +1,5 @@
+iframe {
+  display: block;
+  max-width: 100%;
+  margin: 0 auto;
+}

--- a/src/pages/blog/posts/109-subvisual-weekly-9.md
+++ b/src/pages/blog/posts/109-subvisual-weekly-9.md
@@ -17,7 +17,7 @@ The first edition of [MirrorConf](http://mirrorconf.com/) is closing in, and eve
 
 This week we all need some extra motivation, so I want to remember why we organize conferences, and how much we enjoy it. The following is a video from last year's [RubyConf Portugal](http://rubyconf.pt/), and the best moments from the staff.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/8H8d-mGYjgw" frameborder="0" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/8H8d-mGYjgw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ![file](https://subvisual.s3.amazonaws.com/blog/post_image/188/original.jpg)![file](https://subvisual.s3.amazonaws.com/blog/post_image/190/original.jpg)![file](https://subvisual.s3.amazonaws.com/blog/post_image/191/original.jpg)![file](https://subvisual.s3.amazonaws.com/blog/post_image/192/original.jpg)![file](https://subvisual.s3.amazonaws.com/blog/post_image/193/original.jpg)![file](https://subvisual.s3.amazonaws.com/blog/post_image/194/original.jpg)![file](https://subvisual.s3.amazonaws.com/blog/post_image/189/original.jpg)![file](https://subvisual.s3.amazonaws.com/blog/post_image/195/original.jpg)
 


### PR DESCRIPTION
Why:

* https://subvisual.com/blog/posts/109-subvisual-weekly-9/

  There's an embedded YouTube video in this post that's not correctly
  centered.

This change addresses the issue by:

* Extending the blog post body component with styles for iframes;
* Updating the embedded video tag in the blog post.