### PR TITLE
Fix colors in blog posts list

### DIFF
--- a/src/components/blog/posts_list.module.scss
+++ b/src/components/blog/posts_list.module.scss
@@ -23,7 +23,7 @@
 .posts-list-item {
   padding: 28px 0;
 
-  border-bottom: 1px solid #fcfcfc;
+  border-bottom: 1px solid currentColor;
 
   @media (--desktop) {
     padding: 40px 0;

--- a/src/components/blog/posts_list/entry.js
+++ b/src/components/blog/posts_list/entry.js
@@ -10,9 +10,9 @@ const Entry = ({ author, date, intro, slug, title }) => {
 
   return (
     <div className={styles.root}>
-      <Link to={`/blog/${slug}`} className={styles.title}>
-        {title}
-      </Link>
+      <div className={styles.title}>
+        <Link to={`/blog/${slug}`}>{title}</Link>
+      </div>
       <p className={styles.intro}>
         <Link to={`/blog/${slug}`}>
           {/* eslint-disable-next-line react/no-danger */}

--- a/src/components/blog/posts_list/entry.module.scss
+++ b/src/components/blog/posts_list/entry.module.scss
@@ -17,6 +17,8 @@
   display: block;
   margin-bottom: 20px;
 
+  color: #2421ab;
+
   font-family: "Acta Headline";
   font-size: 20px;
   line-height: 28px;


### PR DESCRIPTION
Why:

* New design uses our dark blue (or purple) for the title;
* The line dividing the posts entries is not using the text color.