### PR TITLE
Fix paragraph margins in blog post block quotes

### DIFF
--- a/src/components/blog/post/body/_blockquote.scss
+++ b/src/components/blog/post/body/_blockquote.scss
@@ -50,10 +50,19 @@ blockquote {
 
   p {
     padding: 0;
+    margin: 20px 0;
+
+    @media (--desktop) {
+      margin: 28px 0;
+    }
   }
 
-  p:not(:last-child) {
-    margin-bottom: 20px;
+  p:first-child {
+    margin-top: 0;
+  }
+
+  p:last-child {
+    margin-bottom: 0;
   }
 
   p:last-child:not(:first-child) {


### PR DESCRIPTION
Why:

* Paragraphs have top margins despite being the first element in the
  block quote.

![Screenshot_2020-04-03 https subvisual com](https://user-images.githubusercontent.com/1141870/78388894-b6982a00-75d9-11ea-8508-0a4034189b0c.png)
