### PR TITLE
Fix tittle placement

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "react-morph": "0.4.0",
     "react-scroll-parallax": "^2.1.1",
     "sass": "^1.26.3",
-    "scroll-lock": "^2.1.2"
+    "scroll-lock": "^2.1.2",
+    "ua-parser-js": "^0.7.21"
   },
   "devDependencies": {
     "eslint": "^6.6.0",

--- a/src/components/home/hero_section/title/animated_letters.js
+++ b/src/components/home/hero_section/title/animated_letters.js
@@ -1,8 +1,11 @@
 import React from "react"
 import PropTypes from "prop-types"
+import classNames from "classnames"
 import { motion } from "framer-motion"
 
 import Planet from "../../../planet"
+import useUserAgent from "../../../../utils/use_user_agent"
+import { isLinux } from "../../../../utils/user_agent_utils"
 
 import styles from "./animated_letters.module.scss"
 
@@ -57,28 +60,36 @@ const renderPlanet = ({ hidden, morph }) => {
   return planet
 }
 
-const HeroTitleAnimatedLetters = ({ hidden, planetMorph }) => (
-  <motion.span
-    variants={dragVariants}
-    animate={hidden ? "out" : "in"}
-    key="without-files"
-  >
-    {renderAnimatedLetters("We nurture ")}
-    <span className={styles.ideas}>
-      <motion.span className={styles.tittleless} variants={letterVariants}>
-        i
-      </motion.span>
-      <span className={styles.planet}>
-        {renderPlanet({ hidden, morph: planetMorph })}
+const HeroTitleAnimatedLetters = ({ hidden, planetMorph }) => {
+  const userAgent = useUserAgent()
+  const className = classNames(styles.root, {
+    [styles.linux]: isLinux(userAgent),
+  })
+
+  return (
+    <motion.span
+      className={className}
+      variants={dragVariants}
+      animate={hidden ? "out" : "in"}
+      key="without-files"
+    >
+      {renderAnimatedLetters("We nurture ")}
+      <span className={styles.ideas}>
+        <motion.span className={styles.tittleless} variants={letterVariants}>
+          i
+        </motion.span>
+        <span className={styles.planet}>
+          {renderPlanet({ hidden, morph: planetMorph })}
+        </span>
+        {renderAnimatedLetters("deas")}
       </span>
-      {renderAnimatedLetters("deas")}
-    </span>
-    <span className={styles.glue}>
-      {renderAnimatedLetters(" that empower ")}
-    </span>
-    {renderAnimatedLetters("people")}
-  </motion.span>
-)
+      <span className={styles.glue}>
+        {renderAnimatedLetters(" that empower ")}
+      </span>
+      {renderAnimatedLetters("people")}
+    </motion.span>
+  )
+}
 
 HeroTitleAnimatedLetters.propTypes = {
   hidden: PropTypes.bool.isRequired,

--- a/src/components/home/hero_section/title/animated_letters.module.scss
+++ b/src/components/home/hero_section/title/animated_letters.module.scss
@@ -20,16 +20,32 @@
   height: 12px;
 
   @include media(">=desktop") {
-    top: 17px;
+    top: 12px;
     left: 6px;
 
     width: 23px;
     height: 23px;
+
+    /**
+     * Fix for letter vertical placement rendering differences.
+     */
+    @-moz-document url-prefix() {
+      top: 17px;
+    }
   }
 }
 
 .glue {
   @media (min-width: 586px) {
     white-space: nowrap;
+  }
+}
+
+/**
+ * Fix for letter vertical placement rendering differences.
+ */
+@include media(">=desktop") {
+  .root.linux .planet {
+    top: 17px;
   }
 }

--- a/src/utils/use_user_agent.js
+++ b/src/utils/use_user_agent.js
@@ -1,0 +1,9 @@
+import UAParser from "ua-parser-js"
+
+export default () => {
+  if (!window || !window.navigator) return undefined
+
+  const parser = new UAParser(window.navigator.userAgent)
+
+  return parser.getResult()
+}

--- a/src/utils/user_agent_utils.js
+++ b/src/utils/user_agent_utils.js
@@ -1,0 +1,3 @@
+export const isLinux = ({ os: { name } }) => name === "Linux"
+
+export default { isLinux }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13271,6 +13271,11 @@ ua-parser-js@^0.7.18:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.20.tgz#7527178b82f6a62a0f243d1f94fd30e3e3c21098"
   integrity sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==
 
+ua-parser-js@^0.7.21:
+  version "0.7.21"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"
+  integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
+
 unbzip2-stream@^1.0.9:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz#d156d205e670d8d8c393e1c02ebd506422873f6a"


### PR DESCRIPTION
Why:

* There's a slight difference in the vertical placement of the letters
  between Firefox and Chrome-based browsers in Linux, and Chrome-based
  browsers in other systems including Edge. This vertical placement
  causes the planet hovering animation in the hero title tittle to
  overlap the _i_ in Chrome based browsers and Edge.

This change addresses the issue by:

* Changing the default position to please Chrome, using the current
  value for Firefox or Linux systems.