### PR TITLE
Remove image placeholders on JS disabled

### DIFF
--- a/src/components/image_loader/index.js
+++ b/src/components/image_loader/index.js
@@ -1,33 +1,37 @@
 import React from "react"
 import { useInView } from "react-intersection-observer"
 import Img from "gatsby-image"
+import _uniqueId from "lodash/uniqueId"
 
 import Placeholder from "../load_placeholder/placeholder"
-import useDetectJavascript from "../../utils/use_detect_javascript"
-
 import styles from "./index.module.css"
 
-const renderPlaceholder = (props, shouldRender) => {
-  if (!shouldRender) return null
-
-  return <Placeholder {...props} />
-}
-
 export default props => {
-  const hasJavascript = useDetectJavascript()
   const { delay, darkOverlay, imgStyle, ...imgProps } = props
   const [loaded, setLoaded] = React.useState(false)
   const [ref, inView] = useInView({
     triggerOnce: true,
     threshold: 0.3,
   })
+  const placeholderId = _uniqueId("image-loader-placeholder-")
 
   return (
     <div ref={ref} className={styles.root}>
-      {renderPlaceholder(
-        { visible: inView && loaded, delay, dark: darkOverlay },
-        hasJavascript
-      )}
+      <noscript>
+        <style>
+          {`
+            #${placeholderId} {
+              display: none
+            }
+          `}
+        </style>
+      </noscript>
+      <Placeholder
+        id={placeholderId}
+        visible={inView && loaded}
+        delay={delay}
+        dark={darkOverlay}
+      />
       <Img
         {...imgProps}
         fadeIn={false}

--- a/src/components/image_loader/index.js
+++ b/src/components/image_loader/index.js
@@ -3,9 +3,13 @@ import { useInView } from "react-intersection-observer"
 import Img from "gatsby-image"
 
 import Placeholder from "../load_placeholder/placeholder"
+import useDetectJavascript from "../../utils/use_detect_javascript"
+
 import styles from "./index.module.css"
 
 export default props => {
+  const hasJavascript = useDetectJavascript()
+
   const { delay, darkOverlay, imgStyle, ...imgProps } = props
   const [loaded, setLoaded] = React.useState(false)
   const [ref, inView] = useInView({
@@ -16,7 +20,7 @@ export default props => {
   return (
     <div ref={ref} className={styles.root}>
       <Placeholder
-        visible={inView && loaded}
+        visible={hasJavascript && inView && loaded}
         delay={delay}
         dark={darkOverlay}
       />

--- a/src/components/image_loader/index.js
+++ b/src/components/image_loader/index.js
@@ -7,9 +7,14 @@ import useDetectJavascript from "../../utils/use_detect_javascript"
 
 import styles from "./index.module.css"
 
+const renderPlaceholder = (props, shouldRender) => {
+  if (!shouldRender) return null
+
+  return <Placeholder {...props} />
+}
+
 export default props => {
   const hasJavascript = useDetectJavascript()
-
   const { delay, darkOverlay, imgStyle, ...imgProps } = props
   const [loaded, setLoaded] = React.useState(false)
   const [ref, inView] = useInView({
@@ -19,11 +24,10 @@ export default props => {
 
   return (
     <div ref={ref} className={styles.root}>
-      <Placeholder
-        visible={hasJavascript && inView && loaded}
-        delay={delay}
-        dark={darkOverlay}
-      />
+      {renderPlaceholder(
+        { visible: inView && loaded, delay, dark: darkOverlay },
+        hasJavascript
+      )}
       <Img
         {...imgProps}
         fadeIn={false}

--- a/src/components/load_placeholder/placeholder.js
+++ b/src/components/load_placeholder/placeholder.js
@@ -4,18 +4,25 @@ import classNames from "classnames"
 
 import styles from "./placeholder.module.css"
 
-const Placeholder = ({ dark, delay, visible }) => {
+const Placeholder = ({ dark, delay, id, visible }) => {
   const className = classNames(styles.root, {
     [styles.dark]: dark,
     [styles.visible]: visible,
   })
 
-  return <div style={{ transitionDelay: `${delay}s` }} className={className} />
+  return (
+    <div
+      className={className}
+      id={id}
+      style={{ transitionDelay: `${delay}s` }}
+    />
+  )
 }
 
 Placeholder.propTypes = {
   dark: PropTypes.bool,
   delay: PropTypes.number,
+  id: PropTypes.string,
   visible: PropTypes.bool,
 }
 


### PR DESCRIPTION
Why:

* If Javascript is disabled all images loaded lazily are not shown
  because the placeholder never leaves.