### PR TITLE
Change the width of the text content in blog posts

### DIFF
--- a/src/components/blog/post/body/_blockquote.scss
+++ b/src/components/blog/post/body/_blockquote.scss
@@ -1,9 +1,11 @@
 @import "common/breakpoints";
 
+@import "./variables";
+
 blockquote {
   position: relative;
 
-  max-width: 618px;
+  max-width: $BlogPostBody-text-maxWidth-mobile;
   padding: 20px 20px 0;
   margin: 56px auto 40px 0;
 
@@ -13,7 +15,7 @@ blockquote {
   line-height: 28px;
 
   @include media(">=desktop") {
-    max-width: 634px;
+    max-width: $BlogPostBody-text-maxWidth-desktop;
     padding: 28px 28px 0 28px;
     margin: 78px auto 56px 0;
 
@@ -43,7 +45,7 @@ blockquote {
 
     @include media(">=desktop") {
       top: -34px;
-      left: 128px;
+      left: 78px;
 
       font-size: 72px;
       line-height: 72px;

--- a/src/components/blog/post/body/_heading.scss
+++ b/src/components/blog/post/body/_heading.scss
@@ -1,3 +1,5 @@
+@import "./variables";
+
 h1 {
   display: none;
 }
@@ -7,14 +9,14 @@ h3,
 h4,
 h5,
 h6 {
-  max-width: 618px;
+  max-width: $BlogPostBody-text-maxWidth-mobile;
   padding: 0 20px;
 
   font-family: colfax-web, sans-serif;
   font-weight: 500;
 
   @include media(">=desktop") {
-    max-width: 634px;
+    max-width: $BlogPostBody-text-maxWidth-desktop;
     padding: 0 28px;
   }
 }

--- a/src/components/blog/post/body/_list.scss
+++ b/src/components/blog/post/body/_list.scss
@@ -1,11 +1,13 @@
+@import "./variables";
+
 ol,
 ul {
-  max-width: 618px;
+  max-width: $BlogPostBody-text-maxWidth-mobile;
   padding: 0 20px 0 40px;
   margin: 20px auto;
 
   @include media(">=desktop") {
-    max-width: 634px;
+    max-width: $BlogPostBody-text-maxWidth-desktop;
     padding: 0 28px 0 56px;
     margin: 28px auto;
   }

--- a/src/components/blog/post/body/_paragraph.scss
+++ b/src/components/blog/post/body/_paragraph.scss
@@ -1,10 +1,12 @@
+@import "./variables";
+
 p {
-  max-width: 618px;
+  max-width: $BlogPostBody-text-maxWidth-mobile;
   padding: 0 20px;
   margin: 20px auto 28px;
 
   @include media(">=desktop") {
-    max-width: 634px;
+    max-width: $BlogPostBody-text-maxWidth-desktop;
     padding: 0 28px;
     margin: 28px auto 32px;
   }

--- a/src/components/blog/post/body/_variables.scss
+++ b/src/components/blog/post/body/_variables.scss
@@ -1,0 +1,5 @@
+/* Text width max-width, which is the value in the design + the side paddings
+ * required to keep things responsive.
+ */
+$BlogPostBody-text-maxWidth-mobile: 718px;
+$BlogPostBody-text-maxWidth-desktop: 734px;


### PR DESCRIPTION
Why:

* As requested in the design.

This change addressed the need by:

* Adding a variables file to be used by the sub-styles in for the blog
  post body with the new text content width values;
* Refactoring all affected content components to use the new variables
  file;
* Tweaking the placement of the quote sign in blockquotes in desktop
  environments.