### PR TITLE
Add blog author pages

### DIFF
--- a/src/components/blog/post/header.js
+++ b/src/components/blog/post/header.js
@@ -1,5 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
+import { Link } from "gatsby"
 import dateFormat from "dateformat"
 
 import Title from "../title"
@@ -7,8 +8,13 @@ import Wrapper from "./wrapper"
 
 import styles from "./header.module.css"
 
+const renderAuthor = ({ key, name }) => (
+  <>
+    By <Link to={`/blog/author/${key}`}>{name}</Link>
+  </>
+)
+
 const BlogPostHeader = ({ author, date, retinaCover, title }) => {
-  const { name: authorName } = author
   const formattedDate = dateFormat(date, "mmmm d, yyyy")
 
   const renderCover = () => {
@@ -34,7 +40,7 @@ const BlogPostHeader = ({ author, date, retinaCover, title }) => {
       {renderCover()}
       <Wrapper padded>
         <div className={styles.info}>
-          <span className={styles.author}>By {authorName}</span>
+          <span className={styles.author}>{renderAuthor(author)}</span>
           <span className={styles.date}>On {formattedDate}</span>
         </div>
       </Wrapper>
@@ -44,6 +50,7 @@ const BlogPostHeader = ({ author, date, retinaCover, title }) => {
 
 BlogPostHeader.propTypes = {
   author: PropTypes.shape({
+    key: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
   }).isRequired,
   date: PropTypes.instanceOf(Date).isRequired,

--- a/src/components/blog/posts_list/entry.js
+++ b/src/components/blog/posts_list/entry.js
@@ -5,8 +5,17 @@ import dateFormat from "dateformat"
 
 import styles from "./entry.module.scss"
 
+const renderAuthor = ({ className, key, name }) => {
+  if (!key || !name) return null
+
+  return (
+    <Link to={`/blog/author/${key}`} className={className}>
+      By {name}
+    </Link>
+  )
+}
+
 const Entry = ({ author, date, intro, path, title }) => {
-  const { name: authorName } = author
   const formattedDate = dateFormat(date, "mmmm d, yyyy")
 
   return (
@@ -21,7 +30,7 @@ const Entry = ({ author, date, intro, path, title }) => {
         </Link>
       </p>
       <div className={styles.info}>
-        <span className={styles.author}>By {authorName}</span>
+        {renderAuthor({ className: styles.author, ...author })}
         <span className={styles.date}>On {formattedDate}</span>
       </div>
     </div>
@@ -30,8 +39,9 @@ const Entry = ({ author, date, intro, path, title }) => {
 
 Entry.propTypes = {
   author: PropTypes.shape({
+    key: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
-  }).isRequired,
+  }),
   date: PropTypes.instanceOf(Date).isRequired,
   intro: PropTypes.string.isRequired,
   path: PropTypes.string.isRequired,

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -14,6 +14,7 @@ const query = graphql`
       nodes {
         frontmatter {
           author {
+            key
             name
           }
           date

--- a/src/templates/blog/author.js
+++ b/src/templates/blog/author.js
@@ -1,0 +1,73 @@
+import React from "react"
+import { graphql } from "gatsby"
+
+import Layout from "../../components/layout"
+import PostsList from "../../components/blog/posts_list"
+import SEO from "../../components/seo"
+import Title from "../../components/blog/title"
+
+import styles from "./author.module.scss"
+
+export const query = graphql`
+  query($authorKey: String!, $blogPostsPathRegex: String!) {
+    allMarkdownRemark(
+      sort: { order: DESC, fields: [frontmatter___date] }
+      filter: {
+        fileAbsolutePath: { regex: $blogPostsPathRegex }
+        frontmatter: { author: { key: { eq: $authorKey } } }
+      }
+    ) {
+      edges {
+        node {
+          frontmatter {
+            date
+            id
+            intro
+            path
+            title
+          }
+        }
+      }
+    }
+    blogContributorYaml(key: { eq: $authorKey }) {
+      name
+      bio
+    }
+    teamMemberYaml(key: { eq: $authorKey }) {
+      name
+      bio
+    }
+  }
+`
+
+const BlogAuthorTemplate = ({ authorName, authorBio, posts }) => (
+  <>
+    <SEO title={`${authorName} — Subvisual`} description={authorBio} />
+    <Layout>
+      <div className={styles.root}>
+        <div className={styles.content}>
+          <Title className={styles.title}>By {authorName}</Title>
+          <PostsList className={styles.postsList} posts={posts} />
+        </div>
+      </div>
+    </Layout>
+  </>
+)
+
+export default ({ data }) => {
+  const {
+    allMarkdownRemark: { edges },
+    blogContributorYaml,
+    teamMemberYaml,
+  } = data
+  const authorYaml = teamMemberYaml || blogContributorYaml
+  const { name: authorName, bio: authorBio } = authorYaml
+  const posts = edges.map(({ node }) => {
+    const { frontmatter } = node
+    const { date, id, intro, path, title } = frontmatter
+
+    return { date: new Date(date), id, intro, path, title }
+  })
+
+  return <BlogAuthorTemplate {...{ authorName, authorBio, posts }} />
+}

--- a/src/templates/blog/author.module.scss
+++ b/src/templates/blog/author.module.scss
@@ -1,0 +1,29 @@
+@import "common/breakpoints";
+
+.root {
+  padding: 28px 20px 56px;
+
+  @include media(">=desktop") {
+    padding: 28px 28px 56px;
+  }
+}
+
+.content {
+  width: 100%;
+  max-width: 1184px;
+  margin: 0 auto;
+}
+
+.title {
+  max-width: 980px;
+  margin: 0 auto 80px;
+
+  @include media(">=desktop") {
+    margin: 0 auto 112px;
+  }
+}
+
+.posts {
+  max-width: 980px;
+  margin: 0 auto;
+}

--- a/src/templates/blog/post.js
+++ b/src/templates/blog/post.js
@@ -15,6 +15,7 @@ export const query = graphql`
       html
       frontmatter {
         author {
+          key
           name
         }
         date


### PR DESCRIPTION
Why:

* Allows listing the blog posts of specific authors.

This change addresses the need by:

* Expanding the dynamic page generation logic to generate a new page for
  each distinct author who wrote a blog post, similar to the root blog
  page with a list of their posts;
* Refactoring blog post headers to link the author's name to the
  respective page;
* Refactoring the post list component entry to accept not having the
  author information in the list of posts, and not render such
  information (to avoid repetition), and link the author's name to the
  respective page when present.