### PR TITLE
Add share links in blog posts pages

### DIFF
--- a/config/node/on_create_node.js
+++ b/config/node/on_create_node.js
@@ -1,7 +1,10 @@
 const path = require("path")
 const isString = require("lodash/isString")
+const isUndefined = require("lodash/isUndefined")
 
 const { isURL } = require("../../src/utils/url_utils")
+
+const { NODE_ENV, URL } = process.env
 
 const resolveBlogPostCover = ({ cover, node }) => {
   const { fileAbsolutePath } = node
@@ -22,12 +25,27 @@ const prepareBlogPostCover = ({ node }) => {
   return cover
 }
 
+const prepareBlogPostUrl = ({ node }) => {
+  if (NODE_ENV === "production" && isUndefined(URL)) {
+    throw new Error(`
+    URL environment variable must be set for production build to allow
+    generation of blog posts URLs.
+    `)
+  }
+
+  const root = isString(URL) ? URL : "http://localhost:8000"
+
+  return path.posix.join(root, "blog", node.frontmatter.path)
+}
+
 module.exports = async ({ node, actions }) => {
   // Skip this logic unless the node was created by processing a markdown file
   if (node.internal.type !== "MarkdownRemark") return
 
   const { createNodeField } = actions
-  const cover = prepareBlogPostCover({ node, actions })
+  const cover = prepareBlogPostCover({ node })
+  const url = prepareBlogPostUrl({ node })
 
   createNodeField({ node, name: "cover", value: cover })
+  createNodeField({ node, name: "url", value: url })
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-intersection-observer": "^8.25.1",
     "react-morph": "0.4.0",
     "react-scroll-parallax": "^2.1.1",
+    "react-share": "^4.1.0",
     "sass": "^1.26.3",
     "scroll-lock": "^2.1.2",
     "ua-parser-js": "^0.7.21"

--- a/src/components/blog/post/body/share_links.js
+++ b/src/components/blog/post/body/share_links.js
@@ -1,0 +1,47 @@
+import React from "react"
+import PropTypes from "prop-types"
+import classNames from "classnames"
+import {
+  FacebookShareButton,
+  LinkedinShareButton,
+  TwitterShareButton,
+} from "react-share"
+
+import useDetectJavascript from "../../../../utils/use_detect_javascript"
+
+import styles from "./share_links.module.scss"
+
+const BlogPostShareLinks = ({ className, url }) => {
+  const hasJavascript = useDetectJavascript()
+
+  // react-share links do not work with JavaScript disabled
+  if (!hasJavascript) return null
+
+  const rootClassName = classNames(styles.root, className)
+
+  return (
+    <div className={rootClassName}>
+      <div className={styles.content}>
+        <div className={styles.title}>Share</div>
+        <ul className={styles.links}>
+          <li className={styles.link}>
+            <FacebookShareButton url={url}>Fb</FacebookShareButton>
+          </li>
+          <li className={styles.link}>
+            <LinkedinShareButton url={url}>In</LinkedinShareButton>
+          </li>
+          <li className={styles.link}>
+            <TwitterShareButton url={url}>Tw</TwitterShareButton>
+          </li>
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+BlogPostShareLinks.propTypes = {
+  className: PropTypes.string,
+  url: PropTypes.string.isRequired,
+}
+
+export default BlogPostShareLinks

--- a/src/components/blog/post/body/share_links.module.scss
+++ b/src/components/blog/post/body/share_links.module.scss
@@ -1,0 +1,76 @@
+@import "common/breakpoints";
+
+@import "./variables";
+
+$breakpoint: 800;
+
+.root {
+  max-width: $BlogPostBody-text-maxWidth-mobile;
+  padding: 0 20px;
+
+  @include media(">=800px") {
+    padding: 0;
+  }
+}
+
+.content {
+  max-width: 718px;
+  margin: 0 auto;
+}
+
+.title {
+  margin-bottom: 20px;
+
+  color: #2421ab;
+
+  line-height: 20px;
+
+  @include media(">=#{$breakpoint}px") {
+    margin-bottom: 28px;
+
+    line-height: 28px;
+  }
+
+  @include media(">=desktop") {
+    margin-bottom: 32px;
+
+    line-height: 32px;
+  }
+}
+
+.links {
+  list-style: none;
+}
+
+.link {
+  display: inline-block;
+  margin-right: 28px;
+
+  color: #2421ab;
+  opacity: 0.6;
+
+  line-height: 20px;
+
+  @include media(">=#{$breakpoint}px") {
+    display: block;
+    margin-right: 0;
+    margin-bottom: 28px;
+
+    line-height: 28px;
+  }
+
+  @include media(">=desktop") {
+    margin-bottom: 32px;
+
+    line-height: 32px;
+  }
+
+  &:hover {
+    opacity: 1;
+  }
+
+  &:last-child {
+    margin-right: 0;
+    margin-bottom: 0;
+  }
+}

--- a/src/components/blog/post/body_wrapper.js
+++ b/src/components/blog/post/body_wrapper.js
@@ -1,17 +1,17 @@
 import React from "react"
 import PropTypes from "prop-types"
-
-import BlogPostWrapper from "./wrapper"
+import classNames from "classnames"
 
 import styles from "./body_wrapper.module.scss"
 
-const BlogPostBodyWrapper = ({ children }) => (
-  <BlogPostWrapper>
-    <div className={styles.content}>{children}</div>
-  </BlogPostWrapper>
-)
+const BlogPostBodyWrapper = ({ className, children }) => {
+  const rootClassName = classNames(styles.root, className)
+
+  return <div className={rootClassName}>{children}</div>
+}
 
 BlogPostBodyWrapper.propTypes = {
+  className: PropTypes.string,
   children: PropTypes.node.isRequired,
 }
 

--- a/src/components/blog/post/body_wrapper.module.scss
+++ b/src/components/blog/post/body_wrapper.module.scss
@@ -2,7 +2,7 @@
 
 @import "./variables";
 
-.content {
+.root {
   max-width: $BlogPost-body-maxWidth-mobile;
   margin-left: auto;
 

--- a/src/components/blog/post/wrapper.js
+++ b/src/components/blog/post/wrapper.js
@@ -1,18 +1,24 @@
 import React from "react"
 import PropTypes from "prop-types"
+import classNames from "classnames"
 
 import PageWideWrapper from "../../page_wide_wrapper"
 
 import styles from "./wrapper.module.css"
 
-const BlogPostWrapper = ({ children, padded }) => (
-  <PageWideWrapper {...{ padded }}>
-    <div className={styles.content}>{children}</div>
-  </PageWideWrapper>
-)
+const BlogPostWrapper = ({ children, className, padded }) => {
+  const contentClassName = classNames(styles.content, className)
+
+  return (
+    <PageWideWrapper {...{ padded }}>
+      <div className={contentClassName}>{children}</div>
+    </PageWideWrapper>
+  )
+}
 
 BlogPostWrapper.propTypes = {
   children: PropTypes.node.isRequired,
+  className: PropTypes.string,
   padded: PropTypes.bool,
 }
 

--- a/src/templates/blog/post.js
+++ b/src/templates/blog/post.js
@@ -3,9 +3,12 @@ import PropTypes from "prop-types"
 import { graphql } from "gatsby"
 
 import Body from "../../components/blog/post/body"
+import BodyWrapper from "../../components/blog/post/body_wrapper"
 import Header from "../../components/blog/post/header"
 import Layout from "../../components/layout"
 import SEO from "../../components/seo"
+import ShareLinks from "../../components/blog/post/body/share_links"
+import Wrapper from "../../components/blog/post/wrapper"
 
 import "../../common/base.scss"
 import styles from "./post.module.scss"
@@ -15,6 +18,7 @@ export const query = graphql`
     markdownRemark(frontmatter: { path: { eq: $slug } }) {
       fields {
         cover
+        url
       }
       frontmatter {
         author {
@@ -36,7 +40,15 @@ export const query = graphql`
   }
 `
 
-const BlogPostTemplate = ({ author, cover, coverFile, date, html, title }) => (
+const BlogPostTemplate = ({
+  author,
+  cover,
+  coverFile,
+  date,
+  html,
+  title,
+  url,
+}) => (
   <Layout>
     <SEO title={title} />
     <div className={styles.root}>
@@ -44,8 +56,13 @@ const BlogPostTemplate = ({ author, cover, coverFile, date, html, title }) => (
         <header className={styles.header}>
           <Header {...{ author, cover, coverFile, date, title }} />
         </header>
-        <section className={styles.body}>
-          <Body html={html} />
+        <section>
+          <Wrapper className={styles.outerWrapper}>
+            <BodyWrapper className={styles.innerWrapper}>
+              <Body html={html} />
+            </BodyWrapper>
+            <ShareLinks className={styles.shareLinks} url={url} />
+          </Wrapper>
         </section>
       </article>
     </div>
@@ -64,18 +81,19 @@ BlogPostTemplate.propTypes = {
 export default ({ data }) => {
   const { markdownRemark, coverFile } = data
   const { fields, frontmatter, html } = markdownRemark
-  const { cover } = fields
+  const { cover, url } = fields
   const { author, date, title } = frontmatter
 
   return (
     <BlogPostTemplate
       {...{
         author,
-        date: new Date(date),
-        html,
         cover,
         coverFile,
+        date: new Date(date),
+        html,
         title,
+        url,
       }}
     />
   )

--- a/src/templates/blog/post.module.scss
+++ b/src/templates/blog/post.module.scss
@@ -7,7 +7,7 @@
 }
 
 .article {
-  padding: 56px 0;
+  padding: 56px 0 84px;
 
   @include media(">=desktop") {
     padding: 0 0 224px;
@@ -19,5 +19,48 @@
 
   @include media(">=desktop") {
     margin-bottom: 112px;
+  }
+}
+
+.outer-wrapper {
+  position: relative;
+
+  margin-bottom: 84px;
+
+  @include media(">=800px") {
+    margin-bottom: 0;
+  }
+}
+
+.inner-wrapper {
+  margin-bottom: 84px;
+
+  @include media(">=800px") {
+    margin-bottom: 0;
+  }
+}
+
+.share-links {
+  display: block;
+  margin: 0 auto;
+
+  @include media(">=800px") {
+    position: absolute;
+    top: 0;
+    left: 20px;
+
+    max-width: 14%;
+  }
+
+  @include media(">=desktop") {
+    left: 28px;
+  }
+
+  @include media(">=1182px") {
+    left: calc(619px - 50vw);
+  }
+
+  @include media(">=1238px") {
+    left: 0;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3313,7 +3313,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.6:
+classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -4159,7 +4159,7 @@ dateformat@^3.0.3:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
+debug@2, debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -8453,6 +8453,13 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
+jsonp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/jsonp/-/jsonp-0.2.1.tgz#a65b4fa0f10bda719a05441ea7b94c55f3e15bae"
+  integrity sha1-pltPoPEL2nGaBUQep7lMVfPhW64=
+  dependencies:
+    debug "^2.1.3"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -11616,6 +11623,14 @@ react-scroll-parallax@^2.1.1:
   integrity sha512-WXiLEwSwYU+lTS2G1mlVYVA+bKwhFpgMvqWMblyD/wjNRrxO1IAxpF2Y1dnaf6jz7wX4CvQHHuSQJfMQnxW0xQ==
   dependencies:
     prop-types "^15.5.10"
+
+react-share@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/react-share/-/react-share-4.1.0.tgz#45cbed5ddcbb24504143bcfc0e9b8a729ce274e0"
+  integrity sha512-4/XqVBC+hreniU08zkzAkOGC3FPdJhcLzt1QCdybsZPd5ieUS++iChEEptvNoksiJ5NxbI2VRoDY9ovLAGl7GQ==
+  dependencies:
+    classnames "^2.2.5"
+    jsonp "^0.2.1"
 
 react-side-effect@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
Why:

* As designed.

This change addresses the need by:

* Adding `react-share`, which seems to be the standard dependency to add
  social sharing links;
* Pre-computing the URL for each blog post after the Markdown node is
  created, relying on the `URL` environment variable which is set on
  Netlify to use the default site name or the custom domain the site was
  set up with (more info in the [Netlify docs]);
* Refactoring the wrapper components used in a blog post to accept a
  custom `className` from the parent components;
* Refactoring the blog post layout to place the sharing links on the
  left of the text, as designed, falling back to the vertical flow at
  the end of the post in mobile.

[Netlify docs]: https://docs.netlify.com/configure-builds/environment-variables/#git-metadata