### PR TITLE
Fixing post listing and header PropTypes

### DIFF
--- a/src/components/blog/post/header.js
+++ b/src/components/blog/post/header.js
@@ -46,8 +46,8 @@ BlogPostHeader.propTypes = {
   author: PropTypes.shape({
     name: PropTypes.string.isRequired,
   }).isRequired,
-  date: PropTypes.instanceOf(Date).isRequired,
-  retinaCover: PropTypes.string.isRequired,
+  date: PropTypes.string.isRequired,
+  retinaCover: PropTypes.string,
   title: PropTypes.string.isRequired,
 }
 

--- a/src/components/blog/post/header.js
+++ b/src/components/blog/post/header.js
@@ -46,7 +46,7 @@ BlogPostHeader.propTypes = {
   author: PropTypes.shape({
     name: PropTypes.string.isRequired,
   }).isRequired,
-  date: PropTypes.string.isRequired,
+  date: PropTypes.instanceOf(Date).isRequired,
   retinaCover: PropTypes.string,
   title: PropTypes.string.isRequired,
 }

--- a/src/components/blog/posts_list.js
+++ b/src/components/blog/posts_list.js
@@ -32,7 +32,6 @@ const renderItem = ({ frontmatter }) => {
     author: authorName,
     path,
     date: new Date(date),
-    slug,
     ...entry,
   }
 

--- a/src/components/blog/posts_list.js
+++ b/src/components/blog/posts_list.js
@@ -25,11 +25,14 @@ const query = graphql`
 `
 
 const renderItem = ({ frontmatter }) => {
-  const { author, id, path, ...entry } = frontmatter
+  const { author, date, id, path, ...entry } = frontmatter
   const { name: authorName } = author
+
   const entryProps = {
     author: authorName,
     path,
+    date: new Date(date),
+    slug,
     ...entry,
   }
 

--- a/src/components/blog/posts_list/entry.js
+++ b/src/components/blog/posts_list/entry.js
@@ -29,7 +29,7 @@ const Entry = ({ author, date, intro, path, title }) => {
 
 Entry.propTypes = {
   author: PropTypes.string.isRequired,
-  date: PropTypes.instanceOf(Date).isRequired,
+  date: PropTypes.string.isRequired,
   intro: PropTypes.string.isRequired,
   path: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,

--- a/src/components/blog/posts_list/entry.js
+++ b/src/components/blog/posts_list/entry.js
@@ -29,7 +29,7 @@ const Entry = ({ author, date, intro, path, title }) => {
 
 Entry.propTypes = {
   author: PropTypes.string.isRequired,
-  date: PropTypes.string.isRequired,
+  date: PropTypes.instanceOf(Date).isRequired,
   intro: PropTypes.string.isRequired,
   path: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,

--- a/src/templates/blog/post.js
+++ b/src/templates/blog/post.js
@@ -42,9 +42,9 @@ const BlogPostTemplate = ({ author, date, html, retinaCover, title }) => (
 
 BlogPostTemplate.propTypes = {
   author: PropTypes.object.isRequired,
-  date: PropTypes.instanceOf(Date).isRequired,
+  date: PropTypes.string.isRequired,
   html: PropTypes.string.isRequired,
-  retinaCover: PropTypes.string.isRequired,
+  retinaCover: PropTypes.string,
   title: PropTypes.string.isRequired,
 }
 

--- a/src/templates/blog/post.js
+++ b/src/templates/blog/post.js
@@ -42,7 +42,7 @@ const BlogPostTemplate = ({ author, date, html, retinaCover, title }) => (
 
 BlogPostTemplate.propTypes = {
   author: PropTypes.object.isRequired,
-  date: PropTypes.string.isRequired,
+  date: PropTypes.instanceOf(Date).isRequired,
   html: PropTypes.string.isRequired,
   retinaCover: PropTypes.string,
   title: PropTypes.string.isRequired,
@@ -53,5 +53,9 @@ export default ({ data }) => {
   const { frontmatter, html } = markdownRemark
   const { author, date, retina_cover: retinaCover, title } = frontmatter
 
-  return <BlogPostTemplate {...{ author, date, html, retinaCover, title }} />
+  return (
+    <BlogPostTemplate
+      {...{ author, date: new Date(date), html, retinaCover, title }}
+    />
+  )
 }


### PR DESCRIPTION
dates were being typed as `typeof(Date)`, which wasn't correct because they seem to always be passed around as a string, and only parsed on the Header component

retinaCover was marked as required, but very few posts actually have it

not sure if this the full fix, or even the correct one. happy to hear feedback

and why are we ignoring the non-retina cover altogether?