### PR TITLE
Make posts list component page agnostic

### DIFF
--- a/src/components/blog/posts_list.js
+++ b/src/components/blog/posts_list.js
@@ -1,59 +1,31 @@
 import React from "react"
-import { useStaticQuery, graphql } from "gatsby"
+import PropTypes from "prop-types"
 
 import Entry from "./posts_list/entry"
 
 import styles from "./posts_list.module.scss"
 
-const query = graphql`
-  {
-    allMarkdownRemark(sort: { order: DESC, fields: [frontmatter___date] }) {
-      nodes {
-        frontmatter {
-          author {
-            name
-          }
-          date
-          id
-          path
-          title
-          intro
-        }
-      }
-    }
-  }
-`
+const renderItem = ({ author, date, intro, id, path, title }) => (
+  <li key={id} className={styles.item}>
+    <Entry {...{ author, date, intro, path, title }} />
+  </li>
+)
 
-const renderItem = ({ frontmatter }) => {
-  const { author, date, id, path, ...entry } = frontmatter
-  const { name: authorName } = author
+const BlogPostsList = ({ posts }) => (
+  <ol className={styles.root}>{posts.map(renderItem)}</ol>
+)
 
-  const entryProps = {
-    author: authorName,
-    path,
-    date: new Date(date),
-    ...entry,
-  }
-
-  return (
-    <li key={id} className={styles.postsListItem}>
-      <Entry {...entryProps} />
-    </li>
-  )
-}
-
-const BlogPostsList = () => {
-  const {
-    allMarkdownRemark: { nodes: postsNodes },
-  } = useStaticQuery(query)
-
-  return (
-    <div className={styles.root}>
-      <div className={styles.content}>
-        <ol className={styles.postsList}>{postsNodes.map(renderItem)}</ol>
-      </div>
-    </div>
-  )
+BlogPostsList.propTypes = {
+  posts: PropTypes.arrayOf(
+    PropTypes.shape({
+      author: PropTypes.object,
+      date: PropTypes.instanceOf(Date).isRequired,
+      id: PropTypes.number.isRequired,
+      intro: PropTypes.string.isRequired,
+      path: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+    })
+  ).isRequired,
 }
 
 export default BlogPostsList

--- a/src/components/blog/posts_list.module.scss
+++ b/src/components/blog/posts_list.module.scss
@@ -1,20 +1,6 @@
 @import "common/breakpoints";
 
 .root {
-  padding: 28px 20px 56px;
-
-  @include media(">=desktop") {
-    padding: 28px 28px 56px;
-  }
-}
-
-.content {
-  width: 100%;
-  max-width: 1184px;
-  margin: 0 auto;
-}
-
-.posts-list {
   width: 100%;
   max-width: 980px;
   margin: 0 auto;
@@ -22,7 +8,7 @@
   list-style: none;
 }
 
-.posts-list-item {
+.item {
   padding: 28px 0;
 
   border-bottom: 1px solid currentColor;

--- a/src/components/blog/posts_list/entry.js
+++ b/src/components/blog/posts_list/entry.js
@@ -6,6 +6,7 @@ import dateFormat from "dateformat"
 import styles from "./entry.module.scss"
 
 const Entry = ({ author, date, intro, path, title }) => {
+  const { name: authorName } = author
   const formattedDate = dateFormat(date, "mmmm d, yyyy")
 
   return (
@@ -20,7 +21,7 @@ const Entry = ({ author, date, intro, path, title }) => {
         </Link>
       </p>
       <div className={styles.info}>
-        <span className={styles.author}>By {author}</span>
+        <span className={styles.author}>By {authorName}</span>
         <span className={styles.date}>On {formattedDate}</span>
       </div>
     </div>
@@ -28,7 +29,9 @@ const Entry = ({ author, date, intro, path, title }) => {
 }
 
 Entry.propTypes = {
-  author: PropTypes.string.isRequired,
+  author: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+  }).isRequired,
   date: PropTypes.instanceOf(Date).isRequired,
   intro: PropTypes.string.isRequired,
   path: PropTypes.string.isRequired,

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -1,13 +1,34 @@
 import React from "react"
+import { useStaticQuery, graphql } from "gatsby"
 
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 import PostsList from "../components/blog/posts_list"
 
 import "../common/base.scss"
+import styles from "./blog.module.scss"
 
-const BlogPage = () => (
-  <Layout currentPath="/blog/">
+const query = graphql`
+  {
+    allMarkdownRemark(sort: { order: DESC, fields: [frontmatter___date] }) {
+      nodes {
+        frontmatter {
+          author {
+            name
+          }
+          date
+          id
+          path
+          title
+          intro
+        }
+      }
+    }
+  }
+`
+
+const BlogPage = ({ posts }) => (
+  <>
     <SEO
       title="Inside Subvisual"
       description={`
@@ -16,8 +37,26 @@ const BlogPage = () => (
             and development, we try to give back by sharing.
           `}
     />
-    <PostsList />
-  </Layout>
+    <Layout currentPath="/blog/">
+      <div className={styles.root}>
+        <div className={styles.content}>
+          <PostsList posts={posts} />
+        </div>
+      </div>
+    </Layout>
+  </>
 )
 
-export default BlogPage
+export default () => {
+  const {
+    allMarkdownRemark: { nodes },
+  } = useStaticQuery(query)
+  const posts = nodes.map(node => {
+    const { frontmatter } = node
+    const { author, date, id, intro, path, title } = frontmatter
+
+    return { author, date: new Date(date), intro, id, path, title }
+  })
+
+  return <BlogPage posts={posts} />
+}

--- a/src/pages/blog.module.scss
+++ b/src/pages/blog.module.scss
@@ -1,0 +1,15 @@
+@import "common/breakpoints";
+
+.root {
+  padding: 28px 20px 56px;
+
+  @include media(">=desktop") {
+    padding: 28px 28px 56px;
+  }
+}
+
+.content {
+  width: 100%;
+  max-width: 1184px;
+  margin: 0 auto;
+}


### PR DESCRIPTION
Why:

* The posts list component is currently bound to the blog root page, and
  it is currently the one querying the data to include in this page;
* We'll need to use this component in other pages, like the authors page
  in preparation in #297.

This change addresses the need by:

* Extracting the data query to the root blog page component;
* Extracting any layout styling external to the posts list itself to the
  root blog page component;
* Refactoring the posts list component to simply render the content
  based on a list of posts provided as a property;
* Refactoring the posts list entry component to extract the author
  information provided as a single object.