### PR TITLE
Extract path utils

### DIFF
--- a/config/node/create_pages.js
+++ b/config/node/create_pages.js
@@ -1,13 +1,11 @@
 const path = require("path")
 
 const blogPostsConfig = require("./blog_posts")
+const { normalizePathForRegex } = require("./path_utils")
 
 const createBlogPostsPages = async ({ createPage, graphql }) => {
   const component = path.resolve("./src/templates/blog/post.js")
-  const basePath = blogPostsConfig.absolutePath.replace(
-    new RegExp("/", "g"),
-    "\\/"
-  )
+  const basePath = normalizePathForRegex(blogPostsConfig.absolutePath)
   const query = `
     {
       allMarkdownRemark(

--- a/config/node/path_utils.js
+++ b/config/node/path_utils.js
@@ -1,0 +1,6 @@
+const normalizePathForRegex = path =>
+  path
+    .replace(new RegExp("/", "g"), "\\/")
+    .replace(new RegExp("\\.", "g"), "\\\\.")
+
+module.exports = { normalizePathForRegex }


### PR DESCRIPTION
Why:

* By default, GatsbyJS does not recognize any files automatically
  besides those under `src/pages`. Those files are the manifests of each
  page to be created, and any code outside those files has to be
  explicitly imported somewhere in their code.

  To automatically recognize any file outside `src/pages` GatsbyJS uses
  the `gatsby-source-filesystem` plugin. We use this plugin to make
  Gatsby aware of things like images, files with data, etc.

  GatsbyJS then uses transformer plugins, such as
  `gatsby-transformer-remark`, that work separately from the previous
  ones. They traverse the files Gatsby is aware of and apply some
  transformation to them, making this transformation available via
  graphQL queries. All products of a configured transformer plugin are
  made available, either as individual nodes of the graph, or as the
  whole collection of nodes created by the plugin.

  The implication is that, by default, by loading all the markdown files
  from various locations of the project, and transforming them all at
  once, we can only get either a specific file, or all the markdown
  files put together in the same bag.

  In order to create the blog posts pages, we filter the markdown files
  by their absolute file path, to ensure only the markdown files from
  the location reserved for posts are considered. This filter is made by
  comparing the absolute path of each markdown file with a regular
  expression.

  Since regular file paths include characters like the forward-slash `/`
  and the period `.` which have a special meaning in a regular
  expression, we need to normalize such paths and escape such
  characters.

  There's a piece of logic in the configuration that creates the blog
  pages dynamically. It is in this place that we normalize the root path
  for blog posts, normalize it, and enter the result in a query to fetch
  the nodes of these files. We'll now need to use this same
  normalization logic for generating the blog post author pages. To
  avoid this repetition, we need to extract the normalization logic into
  its own utility.