### PR TITLE
Optimize blog posts pages generation query

### DIFF
--- a/config/node/create_pages.js
+++ b/config/node/create_pages.js
@@ -10,25 +10,19 @@ const createBlogPostsPages = async ({ createPage, graphql }) => {
     {
       allMarkdownRemark(
         filter: { fileAbsolutePath: { regex: "/^${basePath}/" } },
-        sort: { order: DESC, fields: [frontmatter___date] }
       ) {
-        nodes {
-          frontmatter {
-            path
-          }
-        }
+        distinct(field: frontmatter___path)
       }
     }
   `
   const results = await graphql(query)
 
-  results.data.allMarkdownRemark.nodes.forEach(
-    ({ frontmatter: { path: slug } }) =>
-      createPage({
-        component,
-        context: { slug },
-        path: path.join("/blog", slug),
-      })
+  results.data.allMarkdownRemark.distinct.forEach(slug =>
+    createPage({
+      component,
+      context: { slug },
+      path: path.join("/blog", slug),
+    })
   )
 }
 


### PR DESCRIPTION
Why:

* The current query is sorting the results by date, which is completely
  unnecessary since we want to generate a page for each result, and the
  generation order has no impact whatsoever;
* We can use `distinct` to directly query all distinct values of a
  specific field, and obtain an array with just those values, removing
  the need for further destructuring.