### PR TITLE
Fix potential problems with paths in config

### DIFF
--- a/config/node/blog_posts.js
+++ b/config/node/blog_posts.js
@@ -1,6 +1,0 @@
-const path = require("path")
-
-const relativePath = "src/posts"
-const absolutePath = path.join(__dirname, "../..", relativePath)
-
-module.exports = { absolutePath, relativePath }

--- a/config/node/create_pages.js
+++ b/config/node/create_pages.js
@@ -1,11 +1,11 @@
 const path = require("path")
 
-const blogPostsConfig = require("./blog_posts")
 const { normalizePathForRegex } = require("./path_utils")
 
 const createBlogPostsPages = async ({ createPage, graphql }) => {
-  const component = path.resolve("./src/templates/blog/post.js")
-  const basePath = normalizePathForRegex(blogPostsConfig.absolutePath)
+  const blogPostsAbsolutePath = path.resolve(__dirname, "../../src/posts")
+  const component = path.resolve(__dirname, "../../src/templates/blog/post.js")
+  const basePath = normalizePathForRegex(blogPostsAbsolutePath)
   const query = `
     {
       allMarkdownRemark(
@@ -21,7 +21,7 @@ const createBlogPostsPages = async ({ createPage, graphql }) => {
     createPage({
       component,
       context: { slug },
-      path: path.join("/blog", slug),
+      path: path.posix.join("/blog", slug),
     })
   )
 }

--- a/config/node/create_pages.js
+++ b/config/node/create_pages.js
@@ -2,9 +2,11 @@ const path = require("path")
 
 const { normalizePathForRegex } = require("./path_utils")
 
+const ROOT = path.resolve(__dirname, "../..")
+
 const createBlogPostsPages = async ({ createPage, graphql }) => {
-  const blogPostsAbsolutePath = path.resolve(__dirname, "../../src/posts")
-  const component = path.resolve(__dirname, "../../src/templates/blog/post.js")
+  const blogPostsAbsolutePath = path.resolve(ROOT, "src/posts")
+  const component = path.resolve(ROOT, "src/templates/blog/post.js")
   const basePath = normalizePathForRegex(blogPostsAbsolutePath)
   const query = `
     {

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -2,14 +2,16 @@ const path = require("path")
 const postCssUrl = require("postcss-url")
 const sass = require("sass")
 
+const ROOT = path.resolve(__dirname, "..")
+
 module.exports = [
   {
     resolve: "gatsby-plugin-sass",
     options: {
       implementation: sass,
       includePaths: [
-        path.resolve(__dirname, "../node_modules"),
-        path.resolve(__dirname, "../src"),
+        path.resolve(ROOT, "node_modules"),
+        path.resolve(ROOT, "src"),
       ],
       postCssPlugins: [
         postCssUrl([{ filter: "**/fonts/inline/*", url: "inline" }]),
@@ -21,26 +23,26 @@ module.exports = [
   {
     resolve: "gatsby-source-filesystem",
     options: {
-      path: path.resolve(__dirname, "../src/data"),
+      path: path.resolve(ROOT, "src/data"),
     },
   },
   {
     resolve: "gatsby-source-filesystem",
     options: {
-      path: path.resolve(__dirname, "../src/documents"),
+      path: path.resolve(ROOT, "src/documents"),
     },
   },
   {
     resolve: "gatsby-source-filesystem",
     options: {
       name: "images",
-      path: path.resolve(__dirname, "../src/images"),
+      path: path.resolve(ROOT, "src/images"),
     },
   },
   {
     resolve: "gatsby-source-filesystem",
     options: {
-      path: path.resolve(__dirname, "../src/posts"),
+      path: path.resolve(ROOT, "src/posts"),
     },
   },
   {
@@ -86,7 +88,7 @@ module.exports = [
       background_color: "#ffffff",
       theme_color: "#ffffff",
       display: "minimal-ui",
-      icon: path.resolve(__dirname, "../src/images/subvisual-symbol-blue.svg"),
+      icon: path.resolve(ROOT, "src/images/subvisual-symbol-blue.svg"),
     },
   },
   {

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -2,14 +2,14 @@ const path = require("path")
 const postCssUrl = require("postcss-url")
 const sass = require("sass")
 
-module.exports = root => [
+module.exports = [
   {
     resolve: "gatsby-plugin-sass",
     options: {
       implementation: sass,
       includePaths: [
-        path.resolve(root, "node_modules"),
-        path.resolve(root, "src"),
+        path.resolve(__dirname, "../node_modules"),
+        path.resolve(__dirname, "../src"),
       ],
       postCssPlugins: [
         postCssUrl([{ filter: "**/fonts/inline/*", url: "inline" }]),
@@ -21,26 +21,26 @@ module.exports = root => [
   {
     resolve: "gatsby-source-filesystem",
     options: {
-      path: `${root}/src/data`,
+      path: path.resolve(__dirname, "../src/data"),
     },
   },
   {
     resolve: "gatsby-source-filesystem",
     options: {
-      path: `${root}/src/documents`,
+      path: path.resolve(__dirname, "../src/documents"),
     },
   },
   {
     resolve: "gatsby-source-filesystem",
     options: {
       name: "images",
-      path: `${root}/src/images`,
+      path: path.resolve(__dirname, "../src/images"),
     },
   },
   {
     resolve: "gatsby-source-filesystem",
     options: {
-      path: `${root}/src/posts`,
+      path: path.resolve(__dirname, "../src/posts"),
     },
   },
   {
@@ -86,7 +86,7 @@ module.exports = root => [
       background_color: "#ffffff",
       theme_color: "#ffffff",
       display: "minimal-ui",
-      icon: "src/images/subvisual-symbol-blue.svg",
+      icon: path.resolve(__dirname, "../src/images/subvisual-symbol-blue.svg"),
     },
   },
   {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,4 @@
-const plugins = require("./config/plugins")(__dirname)
+const plugins = require("./config/plugins")
 const siteMetadata = require("./config/site_metadata")
 
 module.exports = { plugins, siteMetadata }


### PR DESCRIPTION
Why:

* The plugins configuration is currently a function of the root of the
  project, but it is unnecessary since we know the root of the project
  from the config file's location.
* #271 added a blog posts config fjile, to retain the variables related
  to the blog posts relevant for the config. Since #302, only the
  absolute path is being used and by a single config file, making this
  external file utterly useless.
* The create pages config is using relative paths to find the blog posts
  pages template.
* When producing the final path of the blog posts pages, we're using a
  tool that joins the path in a system-specific way, when this should
  always be using POSIX paths despite the system it runs on.