### PR TITLE
Use current text size in inline code in blog posts

### DIFF
--- a/src/components/blog/post/body/_inline_code.scss
+++ b/src/components/blog/post/body/_inline_code.scss
@@ -4,6 +4,5 @@ code {
   background-color: rgba(64, 63, 76, 0.1);
   color: inherit; /** Override PrismJS default theme color **/
 
-  font-size: smaller;
   text-shadow: none; /* Override PrismJS default text shadow */
 }


### PR DESCRIPTION
Why:

* #257 added the blog post body component using Source Code Pro for code
  blocks and inline code. Due to this being a larger-than-normal font,
  we styled the inline code to be smaller than the current text size.

  #282 changed the font size in text blocks to Inconsolata precisely for
  being smaller, to give code blocks more capacity for showing up code.
  However, the previous inline rule now makes the inline code too small.