### PR TITLE
Remove IDs from blog posts

### DIFF
--- a/config/node/create_schema_customization.js
+++ b/config/node/create_schema_customization.js
@@ -15,7 +15,6 @@ module.exports = ({ actions }) => {
       }
 
       type Frontmatter {
-        id: Int!,
         author: Author! @link(by: "key"),
         date: Date!,
         path: String!,

--- a/src/components/blog/posts_list.js
+++ b/src/components/blog/posts_list.js
@@ -5,8 +5,8 @@ import Entry from "./posts_list/entry"
 
 import styles from "./posts_list.module.scss"
 
-const renderItem = ({ author, date, intro, id, path, title }) => (
-  <li key={id} className={styles.item}>
+const renderItem = ({ author, date, intro, path, title }, index) => (
+  <li key={index} className={styles.item}>
     <Entry {...{ author, date, intro, path, title }} />
   </li>
 )
@@ -20,7 +20,6 @@ BlogPostsList.propTypes = {
     PropTypes.shape({
       author: PropTypes.object,
       date: PropTypes.instanceOf(Date).isRequired,
-      id: PropTypes.number.isRequired,
       intro: PropTypes.string.isRequired,
       path: PropTypes.string.isRequired,
       title: PropTypes.string.isRequired,

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -18,7 +18,6 @@ const query = graphql`
             name
           }
           date
-          id
           path
           title
           intro
@@ -54,9 +53,9 @@ export default () => {
   } = useStaticQuery(query)
   const posts = nodes.map(node => {
     const { frontmatter } = node
-    const { author, date, id, intro, path, title } = frontmatter
+    const { author, date, intro, path, title } = frontmatter
 
-    return { author, date: new Date(date), intro, id, path, title }
+    return { author, date: new Date(date), intro, path, title }
   })
 
   return <BlogPage posts={posts} />

--- a/src/posts/2013-10-14-this-is-our-story.md
+++ b/src/posts/2013-10-14-this-is-our-story.md
@@ -1,5 +1,4 @@
 ---
-id: 8
 path: /posts/8-this-is-our-story/
 title: "This is Our Story"
 author: roberto-machado

--- a/src/posts/2013-10-21-portuguese-ruby-community-renaissance.md
+++ b/src/posts/2013-10-21-portuguese-ruby-community-renaissance.md
@@ -1,5 +1,4 @@
 ---
-id: 10
 path: /posts/10-portuguese-ruby-community-renaissance/
 title: "Portuguese Ruby Community Renaissance"
 author: roberto-machado

--- a/src/posts/2013-10-23-open-your-html-css-to-developers.md
+++ b/src/posts/2013-10-23-open-your-html-css-to-developers.md
@@ -1,5 +1,4 @@
 ---
-id: 11
 path: /posts/11-open-your-html-css-to-developers/
 title: "Open your HTML/CSS to Developers"
 author: joao-ferreira

--- a/src/posts/2013-10-25-sandi-metz-rules-at-group-buddies.md
+++ b/src/posts/2013-10-25-sandi-metz-rules-at-group-buddies.md
@@ -1,5 +1,4 @@
 ---
-id: 12
 path: /posts/12-sandi-metz-rules-at-group-buddies/
 title: "Sandi Metz rules at Group Buddies"
 author: luis-zamith

--- a/src/posts/2013-10-29-when-an-experiment-blows-your-mind.md
+++ b/src/posts/2013-10-29-when-an-experiment-blows-your-mind.md
@@ -1,5 +1,4 @@
 ---
-id: 13
 path: /posts/13-when-an-experiment-blows-your-mind/
 title: "When an experiment blows your mind"
 author: roberto-machado

--- a/src/posts/2013-11-19-talking-about-design-explorers-festival.md
+++ b/src/posts/2013-11-19-talking-about-design-explorers-festival.md
@@ -1,5 +1,4 @@
 ---
-id: 15
 path: /posts/15-talking-about-design-explorers-festival/
 title: "Talking about design @ Explorers Festival"
 author: joao-ferreira

--- a/src/posts/2013-11-22-dependency-injection.md
+++ b/src/posts/2013-11-22-dependency-injection.md
@@ -1,5 +1,4 @@
 ---
-id: 16
 path: /posts/16-dependency-injection/
 title: "Dependency Injection"
 author: luis-zamith

--- a/src/posts/2013-11-26-teaching-kids-how-to-code.md
+++ b/src/posts/2013-11-26-teaching-kids-how-to-code.md
@@ -1,5 +1,4 @@
 ---
-id: 17
 path: /posts/17-teaching-kids-how-to-code/
 title: "Teaching Kids How to Code"
 author: roberto-machado

--- a/src/posts/2013-11-29-solid-principles-in-ruby.md
+++ b/src/posts/2013-11-29-solid-principles-in-ruby.md
@@ -1,5 +1,4 @@
 ---
-id: 19
 path: /posts/19-solid-principles-in-ruby/
 title: "SOLID Principles in Ruby"
 author: luis-zamith

--- a/src/posts/2013-12-03-let-s-talk-tools.md
+++ b/src/posts/2013-12-03-let-s-talk-tools.md
@@ -1,5 +1,4 @@
 ---
-id: 18
 path: /posts/18-let-s-talk-tools/
 title: "Let's Talk Tools"
 author: roberto-machado

--- a/src/posts/2013-12-27-clean-architecture.md
+++ b/src/posts/2013-12-27-clean-architecture.md
@@ -1,5 +1,4 @@
 ---
-id: 20
 path: /posts/20-clean-architecture/
 title: "Clean Architecture"
 author: luis-zamith

--- a/src/posts/2014-01-03-a-toast-to-2013-welcome-2014.md
+++ b/src/posts/2014-01-03-a-toast-to-2013-welcome-2014.md
@@ -1,5 +1,4 @@
 ---
-id: 21
 path: /posts/21-a-toast-to-2013-welcome-2014/
 title: "A Toast To 2013! Welcome 2014"
 author: roberto-machado

--- a/src/posts/2014-01-07-using-calc-for-responsive-css.md
+++ b/src/posts/2014-01-07-using-calc-for-responsive-css.md
@@ -1,5 +1,4 @@
 ---
-id: 23
 path: /posts/23-using-calc-for-responsive-css/
 title: "Using calc() for responsive CSS"
 author: gabriel-poca

--- a/src/posts/2014-01-14-why-provisioning-matters.md
+++ b/src/posts/2014-01-14-why-provisioning-matters.md
@@ -1,5 +1,4 @@
 ---
-id: 24
 path: /posts/24-why-provisioning-matters/
 title: "Why Provisioning Matters"
 author: miguel-palhas

--- a/src/posts/2014-01-17-design-solutions-not-decorations.md
+++ b/src/posts/2014-01-17-design-solutions-not-decorations.md
@@ -1,5 +1,4 @@
 ---
-id: 25
 path: /posts/25-design-solutions-not-decorations/
 title: "Design solutions, not decorations"
 author: joao-ferreira

--- a/src/posts/2014-02-11-designer-s-secret-sauce.md
+++ b/src/posts/2014-02-11-designer-s-secret-sauce.md
@@ -1,5 +1,4 @@
 ---
-id: 28
 path: /posts/28-designer-s-secret-sauce/
 title: "Designer's secret sauce"
 author: joao-ferreira

--- a/src/posts/2014-03-20-open-source-fridays.md
+++ b/src/posts/2014-03-20-open-source-fridays.md
@@ -1,5 +1,4 @@
 ---
-id: 29
 path: /posts/29-open-source-fridays/
 title: "Open Source Fridays"
 author: luis-zamith

--- a/src/posts/2014-03-24-open-source-fridays-2nd-edition.md
+++ b/src/posts/2014-03-24-open-source-fridays-2nd-edition.md
@@ -1,5 +1,4 @@
 ---
-id: 30
 path: /posts/30-open-source-fridays-2nd-edition/
 title: "Open Source Fridays - 2nd Edition"
 author: luis-zamith

--- a/src/posts/2014-03-28-brace-yourselves-rubyconf-pt-is-coming.md
+++ b/src/posts/2014-03-28-brace-yourselves-rubyconf-pt-is-coming.md
@@ -1,5 +1,4 @@
 ---
-id: 31
 path: /posts/31-brace-yourselves-rubyconf-pt-is-coming/
 title: "Brace Yourselves, RubyConf PT is coming!"
 author: roberto-machado

--- a/src/posts/2014-03-31-our-css-sass-project-architecture-and-styleguide.md
+++ b/src/posts/2014-03-31-our-css-sass-project-architecture-and-styleguide.md
@@ -1,5 +1,4 @@
 ---
-id: 32
 path: /posts/32-our-css-sass-project-architecture-and-styleguide/
 title: "Our CSS/Sass Project Architecture and Styleguide"
 author: bruno-azevedo

--- a/src/posts/2014-04-08-better-pushes-with-git.md
+++ b/src/posts/2014-04-08-better-pushes-with-git.md
@@ -1,5 +1,4 @@
 ---
-id: 33
 path: /posts/33-better-pushes-with-git/
 title: "Better pushes with git"
 author: luis-zamith

--- a/src/posts/2014-04-14-the-keyword-arguments-falacy.md
+++ b/src/posts/2014-04-14-the-keyword-arguments-falacy.md
@@ -1,5 +1,4 @@
 ---
-id: 34
 path: /posts/34-the-keyword-arguments-falacy/
 title: "The keyword arguments falacy"
 author: luis-zamith

--- a/src/posts/2014-05-14-we-are-hiring.md
+++ b/src/posts/2014-05-14-we-are-hiring.md
@@ -1,5 +1,4 @@
 ---
-id: 36
 path: /posts/36-we-are-hiring/
 title: "We are hiring!"
 author: roberto-machado

--- a/src/posts/2014-05-21-dipping-the-toes-in-phonegap.md
+++ b/src/posts/2014-05-21-dipping-the-toes-in-phonegap.md
@@ -1,5 +1,4 @@
 ---
-id: 35
 path: /posts/35-dipping-the-toes-in-phonegap/
 title: "Dipping the toes in Phonegap"
 author: gabriel-poca

--- a/src/posts/2014-05-29-random-and-probably-useless-rubyisms.md
+++ b/src/posts/2014-05-29-random-and-probably-useless-rubyisms.md
@@ -1,5 +1,4 @@
 ---
-id: 37
 path: /posts/37-random-and-probably-useless-rubyisms/
 title: "Random (and probably useless) Rubyisms"
 author: miguel-palhas

--- a/src/posts/2014-06-17-announcing-our-summer-apprenticeship-program.md
+++ b/src/posts/2014-06-17-announcing-our-summer-apprenticeship-program.md
@@ -1,5 +1,4 @@
 ---
-id: 38
 path: /posts/38-announcing-our-summer-apprenticeship-program/
 title: "Announcing our Summer Apprenticeship Program"
 author: roberto-machado

--- a/src/posts/2014-06-18-adapting-education-to-the-way-we-learn.md
+++ b/src/posts/2014-06-18-adapting-education-to-the-way-we-learn.md
@@ -1,5 +1,4 @@
 ---
-id: 40
 path: /posts/40-adapting-education-to-the-way-we-learn/
 title: "Adapting education to the way we learn"
 author: joao-ferreira

--- a/src/posts/2014-06-24-tutorial-html-audio-capture-streaming-to-node-js-no-browser-extensions.md
+++ b/src/posts/2014-06-24-tutorial-html-audio-capture-streaming-to-node-js-no-browser-extensions.md
@@ -1,5 +1,4 @@
 ---
-id: 39
 path: /posts/39-tutorial-html-audio-capture-streaming-to-node-js-no-browser-extensions/
 title: "Tutorial: HTML Audio Capture streaming to Node.js (no browser extensions)"
 author: gabriel-poca

--- a/src/posts/2014-07-01-why-you-should-care-about-design.md
+++ b/src/posts/2014-07-01-why-you-should-care-about-design.md
@@ -1,5 +1,4 @@
 ---
-id: 41
 path: /posts/41-why-you-should-care-about-design/
 title: "Why you should care about Design"
 author: joao-ferreira

--- a/src/posts/2014-09-25-overview-of-meteor-cordova-phonegap-integration.md
+++ b/src/posts/2014-09-25-overview-of-meteor-cordova-phonegap-integration.md
@@ -1,5 +1,4 @@
 ---
-id: 42
 path: /posts/42-overview-of-meteor-cordova-phonegap-integration/
 title: "Overview of Meteor Cordova - PhoneGap integration"
 author: joao-justo

--- a/src/posts/2014-11-17-supercharge-your-git.md
+++ b/src/posts/2014-11-17-supercharge-your-git.md
@@ -1,5 +1,4 @@
 ---
-id: 43
 path: /posts/43-supercharge-your-git/
 title: "Supercharge your git"
 author: luis-zamith

--- a/src/posts/2014-11-24-easily-merging-pull-requests.md
+++ b/src/posts/2014-11-24-easily-merging-pull-requests.md
@@ -1,5 +1,4 @@
 ---
-id: 44
 path: /posts/44-easily-merging-pull-requests/
 title: "Easily Merging Pull Requests"
 author: miguel-palhas

--- a/src/posts/2014-11-26-offline-web-apps-with-meteor.md
+++ b/src/posts/2014-11-26-offline-web-apps-with-meteor.md
@@ -1,5 +1,4 @@
 ---
-id: 45
 path: /posts/45-offline-web-apps-with-meteor/
 title: "Offline Web Apps with Meteor"
 author: gabriel-poca

--- a/src/posts/2014-11-27-my-experience-as-an-apprentice.md
+++ b/src/posts/2014-11-27-my-experience-as-an-apprentice.md
@@ -1,5 +1,4 @@
 ---
-id: 46
 path: /posts/46-my-experience-as-an-apprentice/
 title: "My experience as an apprentice"
 author: joao-justo

--- a/src/posts/2014-12-10-for-makers.md
+++ b/src/posts/2014-12-10-for-makers.md
@@ -1,5 +1,4 @@
 ---
-id: 47
 path: /posts/47-for-makers/
 title: "For Makers"
 author: joao-ferreira

--- a/src/posts/2014-12-19-lessons-learned-from-our-winter-company-retreat.md
+++ b/src/posts/2014-12-19-lessons-learned-from-our-winter-company-retreat.md
@@ -1,5 +1,4 @@
 ---
-id: 48
 path: /posts/48-lessons-learned-from-our-winter-company-retreat/
 title: "Lessons Learned from our Winter Company Retreat"
 author: roberto-machado

--- a/src/posts/2015-02-02-accessibility-matters.md
+++ b/src/posts/2015-02-02-accessibility-matters.md
@@ -1,5 +1,4 @@
 ---
-id: 50
 path: /posts/50-accessibility-matters/
 title: "Accessibility Matters"
 author: luis-zamith

--- a/src/posts/2015-02-18-getting-hooked.md
+++ b/src/posts/2015-02-18-getting-hooked.md
@@ -1,5 +1,4 @@
 ---
-id: 51
 path: /posts/51-getting-hooked/
 title: "Getting Hooked"
 author: miguel-palhas

--- a/src/posts/2015-02-27-game-on-rubyconf-portugal-is-back-in-2015.md
+++ b/src/posts/2015-02-27-game-on-rubyconf-portugal-is-back-in-2015.md
@@ -1,5 +1,4 @@
 ---
-id: 52
 path: /posts/52-game-on-rubyconf-portugal-is-back-in-2015/
 title: "Game On! RubyConf Portugal is back in 2015"
 author: roberto-machado

--- a/src/posts/2015-04-09-a-better-reset-for-the-mobile-web.md
+++ b/src/posts/2015-04-09-a-better-reset-for-the-mobile-web.md
@@ -1,5 +1,4 @@
 ---
-id: 53
 path: /posts/53-a-better-reset-for-the-mobile-web/
 title: "A better reset for the mobile web"
 author: gabriel-poca

--- a/src/posts/2015-04-13-the-pursuit-of-craftsmanship.md
+++ b/src/posts/2015-04-13-the-pursuit-of-craftsmanship.md
@@ -1,5 +1,4 @@
 ---
-id: 54
 path: /posts/54-the-pursuit-of-craftsmanship/
 title: "The Pursuit of Craftsmanship "
 author: francisco-baila

--- a/src/posts/2015-07-01-our-biggest-announcement-yet.md
+++ b/src/posts/2015-07-01-our-biggest-announcement-yet.md
@@ -1,5 +1,4 @@
 ---
-id: 58
 path: /posts/58-our-biggest-announcement-yet/
 title: "Our Biggest Announcement Yet"
 author: roberto-machado

--- a/src/posts/2015-07-06-why-subvisual.md
+++ b/src/posts/2015-07-06-why-subvisual.md
@@ -1,5 +1,4 @@
 ---
-id: 59
 path: /posts/59-why-subvisual/
 title: "Why Subvisual?"
 author: joao-ferreira

--- a/src/posts/2015-07-15-deploying-a-crystal-application-to-heroku.md
+++ b/src/posts/2015-07-15-deploying-a-crystal-application-to-heroku.md
@@ -1,5 +1,4 @@
 ---
-id: 63
 path: /posts/63-deploying-a-crystal-application-to-heroku/
 title: "Deploying a Crystal application to Heroku"
 author: luis-zamith

--- a/src/posts/2015-07-17-perfecting-a-css-3d-animation.md
+++ b/src/posts/2015-07-17-perfecting-a-css-3d-animation.md
@@ -1,5 +1,4 @@
 ---
-id: 62
 path: /posts/62-perfecting-a-css-3d-animation/
 title: "Perfecting a CSS 3D animation "
 author: miguel-palhas

--- a/src/posts/2015-10-07-shaping-a-school.md
+++ b/src/posts/2015-10-07-shaping-a-school.md
@@ -1,5 +1,4 @@
 ---
-id: 65
 path: /posts/65-shaping-a-school/
 title: "Shaping a School"
 author: francisco-baila

--- a/src/posts/2015-11-18-hacking-your-own-company.md
+++ b/src/posts/2015-11-18-hacking-your-own-company.md
@@ -1,5 +1,4 @@
 ---
-id: 64
 path: /posts/64-hacking-your-own-company/
 title: "Hacking your own company"
 author: joao-justo

--- a/src/posts/2015-12-02-sending-multiple-emails-with-actionmailer.md
+++ b/src/posts/2015-12-02-sending-multiple-emails-with-actionmailer.md
@@ -1,5 +1,4 @@
 ---
-id: 66
 path: /posts/66-sending-multiple-emails-with-actionmailer/
 title: "Sending multiple emails with ActionMailer"
 author: luis-zamith

--- a/src/posts/2016-01-06-newsletter-as-a-team-building-exercise.md
+++ b/src/posts/2016-01-06-newsletter-as-a-team-building-exercise.md
@@ -1,5 +1,4 @@
 ---
-id: 67
 path: /posts/67-newsletter-as-a-team-building-exercise/
 title: "Newsletter as a team building exercise"
 author: laura-esteves

--- a/src/posts/2016-01-22-undersampling-of-failure.md
+++ b/src/posts/2016-01-22-undersampling-of-failure.md
@@ -1,5 +1,4 @@
 ---
-id: 69
 path: /posts/69-undersampling-of-failure/
 title: "Undersampling of Failure"
 author: roberto-machado

--- a/src/posts/2016-01-28-a-late-recap-of-2015.md
+++ b/src/posts/2016-01-28-a-late-recap-of-2015.md
@@ -1,5 +1,4 @@
 ---
-id: 68
 path: /posts/68-a-late-recap-of-2015/
 title: "A Late Recap of 2015"
 author: roberto-machado

--- a/src/posts/2016-02-25-life-after-apprenticeship.md
+++ b/src/posts/2016-02-25-life-after-apprenticeship.md
@@ -1,5 +1,4 @@
 ---
-id: 70
 path: /posts/70-life-after-apprenticeship/
 title: "Life After Apprenticeship"
 author: francisco-baila

--- a/src/posts/2016-03-03-factorygirl-beyond-the-database.md
+++ b/src/posts/2016-03-03-factorygirl-beyond-the-database.md
@@ -1,5 +1,4 @@
 ---
-id: 73
 path: /posts/73-factorygirl-beyond-the-database/
 title: "FactoryGirl Beyond the Database"
 author: miguel-palhas

--- a/src/posts/2016-03-15-ruby-bits-br-each-with-object.md
+++ b/src/posts/2016-03-15-ruby-bits-br-each-with-object.md
@@ -1,5 +1,4 @@
 ---
-id: 74
 path: /posts/74-ruby-bits-br-each-with-object/
 title: "Ruby Bits:  Each with object"
 author: luis-zamith

--- a/src/posts/2016-03-21-culture-design.md
+++ b/src/posts/2016-03-21-culture-design.md
@@ -1,5 +1,4 @@
 ---
-id: 77
 path: /posts/77-culture-design/
 title: "Culture Design"
 author: joao-ferreira

--- a/src/posts/2016-03-29-ruby-bits-br-bundle-open.md
+++ b/src/posts/2016-03-29-ruby-bits-br-bundle-open.md
@@ -1,5 +1,4 @@
 ---
-id: 75
 path: /posts/75-ruby-bits-br-bundle-open/
 title: "Ruby Bits:  Bundle open"
 author: luis-zamith

--- a/src/posts/2016-04-08-rubyconf-portugal-br-is-back.md
+++ b/src/posts/2016-04-08-rubyconf-portugal-br-is-back.md
@@ -1,5 +1,4 @@
 ---
-id: 78
 path: /posts/78-rubyconf-portugal-br-is-back/
 title: "RubyConf Portugal  is back!"
 author: roberto-machado

--- a/src/posts/2016-04-12-ruby-bits-br-enumerators.md
+++ b/src/posts/2016-04-12-ruby-bits-br-enumerators.md
@@ -1,5 +1,4 @@
 ---
-id: 76
 path: /posts/76-ruby-bits-br-enumerators/
 title: "Ruby Bits:  Enumerators"
 author: luis-zamith

--- a/src/posts/2016-04-26-ruby-bits-br-delegation.md
+++ b/src/posts/2016-04-26-ruby-bits-br-delegation.md
@@ -1,5 +1,4 @@
 ---
-id: 80
 path: /posts/80-ruby-bits-br-delegation/
 title: "Ruby Bits:  Delegation"
 author: luis-zamith

--- a/src/posts/2016-04-28-a-bridge-between-redux-and-meteor.md
+++ b/src/posts/2016-04-28-a-bridge-between-redux-and-meteor.md
@@ -1,5 +1,4 @@
 ---
-id: 79
 path: /posts/79-a-bridge-between-redux-and-meteor/
 title: "A bridge between Redux and Meteor"
 author: gabriel-poca

--- a/src/posts/2016-05-10-rubybits-br-type-coercion.md
+++ b/src/posts/2016-05-10-rubybits-br-type-coercion.md
@@ -1,5 +1,4 @@
 ---
-id: 81
 path: /posts/81-rubybits-br-type-coercion/
 title: "RubyBits:  Type coercion"
 author: luis-zamith

--- a/src/posts/2016-05-16-team-shared-responsibility.md
+++ b/src/posts/2016-05-16-team-shared-responsibility.md
@@ -1,5 +1,4 @@
 ---
-id: 82
 path: /posts/82-team-shared-responsibility/
 title: "Team-shared Responsibility"
 author: joao-ferreira

--- a/src/posts/2016-05-18-announcing-br-mirror-conf.md
+++ b/src/posts/2016-05-18-announcing-br-mirror-conf.md
@@ -1,5 +1,4 @@
 ---
-id: 83
 path: /posts/83-announcing-br-mirror-conf/
 title: "Announcing Mirror Conf"
 author: roberto-machado

--- a/src/posts/2016-05-24-rubybits-br-source-diving.md
+++ b/src/posts/2016-05-24-rubybits-br-source-diving.md
@@ -1,5 +1,4 @@
 ---
-id: 85
 path: /posts/85-rubybits-br-source-diving/
 title: "RubyBits:  Source Diving"
 author: luis-zamith

--- a/src/posts/2016-06-01-launching-subvisual-s-summer-camp.md
+++ b/src/posts/2016-06-01-launching-subvisual-s-summer-camp.md
@@ -1,5 +1,4 @@
 ---
-id: 84
 path: /posts/84-launching-subvisual-s-summer-camp/
 title: "Launching Subvisual's Summer Camp"
 author: roberto-machado

--- a/src/posts/2016-06-02-smarter-heredoc-syntax-in-vim.md
+++ b/src/posts/2016-06-02-smarter-heredoc-syntax-in-vim.md
@@ -1,5 +1,4 @@
 ---
-id: 87
 path: /posts/87-smarter-heredoc-syntax-in-vim/
 title: "Smarter heredoc syntax in vim"
 author: miguel-palhas

--- a/src/posts/2016-06-14-rubybits-br-triple-equals.md
+++ b/src/posts/2016-06-14-rubybits-br-triple-equals.md
@@ -1,5 +1,4 @@
 ---
-id: 88
 path: /posts/88-rubybits-br-triple-equals/
 title: "RubyBits:  Triple Equals"
 author: luis-zamith

--- a/src/posts/2016-06-22-stumbling-into-a-product.md
+++ b/src/posts/2016-06-22-stumbling-into-a-product.md
@@ -1,5 +1,4 @@
 ---
-id: 89
 path: /posts/89-stumbling-into-a-product/
 title: "Stumbling into a product"
 author: luis-zamith

--- a/src/posts/2016-07-05-ruby-bits-br-spaceship-operator.md
+++ b/src/posts/2016-07-05-ruby-bits-br-spaceship-operator.md
@@ -1,5 +1,4 @@
 ---
-id: 90
 path: /posts/90-ruby-bits-br-spaceship-operator/
 title: "Ruby Bits:  Spaceship Operator"
 author: luis-zamith

--- a/src/posts/2016-07-19-we-would-like-to-meet-you.md
+++ b/src/posts/2016-07-19-we-would-like-to-meet-you.md
@@ -1,5 +1,4 @@
 ---
-id: 93
 path: /posts/93-we-would-like-to-meet-you/
 title: "We would like to meet you"
 author: luis-zamith

--- a/src/posts/2016-07-22-subvisual-weekly-1.md
+++ b/src/posts/2016-07-22-subvisual-weekly-1.md
@@ -1,5 +1,4 @@
 ---
-id: 92
 path: /posts/92-subvisual-weekly-1/
 title: "Subvisual Weekly #1"
 author: gabriel-poca

--- a/src/posts/2016-07-29-subvisual-weekly-2.md
+++ b/src/posts/2016-07-29-subvisual-weekly-2.md
@@ -1,5 +1,4 @@
 ---
-id: 95
 path: /posts/95-subvisual-weekly-2/
 title: "Subvisual Weekly #2"
 author: gabriel-poca

--- a/src/posts/2016-08-02-from-client-to-partner.md
+++ b/src/posts/2016-08-02-from-client-to-partner.md
@@ -1,5 +1,4 @@
 ---
-id: 91
 path: /posts/91-from-client-to-partner/
 title: "From Client to Partner"
 author: joao-ferreira

--- a/src/posts/2016-08-04-subvisual-is-expanding-to-the-us.md
+++ b/src/posts/2016-08-04-subvisual-is-expanding-to-the-us.md
@@ -1,5 +1,4 @@
 ---
-id: 94
 path: /posts/94-subvisual-is-expanding-to-the-us/
 title: "Subvisual is expanding to the US"
 author: roberto-machado

--- a/src/posts/2016-08-08-subvisual-weekly-3.md
+++ b/src/posts/2016-08-08-subvisual-weekly-3.md
@@ -1,5 +1,4 @@
 ---
-id: 97
 path: /posts/97-subvisual-weekly-3/
 title: "Subvisual Weekly #3"
 author: gabriel-poca

--- a/src/posts/2016-08-11-a-look-into-bloom-filters-with-ruby.md
+++ b/src/posts/2016-08-11-a-look-into-bloom-filters-with-ruby.md
@@ -1,5 +1,4 @@
 ---
-id: 96
 path: /posts/96-a-look-into-bloom-filters-with-ruby/
 title: "A Look Into Bloom Filters with Ruby"
 author: fernando-mendes

--- a/src/posts/2016-08-16-subvisual-weekly-4.md
+++ b/src/posts/2016-08-16-subvisual-weekly-4.md
@@ -1,5 +1,4 @@
 ---
-id: 99
 path: /posts/99-subvisual-weekly-4/
 title: "Subvisual Weekly #4"
 author: joao-justo

--- a/src/posts/2016-08-22-subvisual-weekly-5.md
+++ b/src/posts/2016-08-22-subvisual-weekly-5.md
@@ -1,5 +1,4 @@
 ---
-id: 101
 path: /posts/101-subvisual-weekly-5/
 title: "Subvisual Weekly #5"
 author: gabriel-poca

--- a/src/posts/2016-08-29-subvisual-weekly-6.md
+++ b/src/posts/2016-08-29-subvisual-weekly-6.md
@@ -1,5 +1,4 @@
 ---
-id: 103
 path: /posts/103-subvisual-weekly-6/
 title: "Subvisual Weekly #6"
 author: gabriel-poca

--- a/src/posts/2016-09-05-subvisual-weekly-7.md
+++ b/src/posts/2016-09-05-subvisual-weekly-7.md
@@ -1,5 +1,4 @@
 ---
-id: 104
 path: /posts/104-subvisual-weekly-7/
 title: "Subvisual Weekly #7"
 author: fernando-mendes

--- a/src/posts/2016-09-09-first-steps-into-product-design.md
+++ b/src/posts/2016-09-09-first-steps-into-product-design.md
@@ -1,5 +1,4 @@
 ---
-id: 105
 path: /posts/105-first-steps-into-product-design/
 title: "First steps into product design"
 author: summer-campers

--- a/src/posts/2016-09-13-weekly-8.md
+++ b/src/posts/2016-09-13-weekly-8.md
@@ -1,5 +1,4 @@
 ---
-id: 106
 path: /posts/106-weekly-8/
 title: "Weekly #8"
 author: gabriel-poca

--- a/src/posts/2016-09-15-educating-for-design-context-context-context.md
+++ b/src/posts/2016-09-15-educating-for-design-context-context-context.md
@@ -1,5 +1,4 @@
 ---
-id: 107
 path: /posts/107-educating-for-design-context-context-context/
 title: "Educating for design: Context, context, context"
 author: joao-ferreira

--- a/src/posts/2016-09-20-subvisual-weekly-9.md
+++ b/src/posts/2016-09-20-subvisual-weekly-9.md
@@ -1,5 +1,4 @@
 ---
-id: 109
 path: /posts/109-subvisual-weekly-9/
 title: "Subvisual Weekly #9"
 author: gabriel-poca

--- a/src/posts/2016-09-28-trying-to-stop-the-madness.md
+++ b/src/posts/2016-09-28-trying-to-stop-the-madness.md
@@ -1,5 +1,4 @@
 ---
-id: 72
 path: /posts/72-trying-to-stop-the-madness/
 title: "Trying to stop the madness"
 author: francisco-baila

--- a/src/posts/2016-09-29-subvisual-weekly-10.md
+++ b/src/posts/2016-09-29-subvisual-weekly-10.md
@@ -1,5 +1,4 @@
 ---
-id: 110
 path: /posts/110-subvisual-weekly-10/
 title: "Subvisual Weekly #10"
 author: summer-campers

--- a/src/posts/2016-10-03-an-exercise-in-futility.md
+++ b/src/posts/2016-10-03-an-exercise-in-futility.md
@@ -1,5 +1,4 @@
 ---
-id: 111
 path: /posts/111-an-exercise-in-futility/
 title: "An exercise in futility"
 author: miguel-palhas

--- a/src/posts/2016-10-07-subvisual-weekly-11.md
+++ b/src/posts/2016-10-07-subvisual-weekly-11.md
@@ -1,5 +1,4 @@
 ---
-id: 112
 path: /posts/112-subvisual-weekly-11/
 title: "Subvisual Weekly #11"
 author: gabriel-poca

--- a/src/posts/2016-10-14-subvisual-weekly-12.md
+++ b/src/posts/2016-10-14-subvisual-weekly-12.md
@@ -1,5 +1,4 @@
 ---
-id: 114
 path: /posts/114-subvisual-weekly-12/
 title: "Subvisual Weekly #12"
 author: gabriel-poca

--- a/src/posts/2016-10-17-a-rollercoaster-called-mirror-conf.md
+++ b/src/posts/2016-10-17-a-rollercoaster-called-mirror-conf.md
@@ -1,5 +1,4 @@
 ---
-id: 113
 path: /posts/113-a-rollercoaster-called-mirror-conf/
 title: "A rollercoaster called Mirror Conf"
 author: joao-ferreira

--- a/src/posts/2016-10-19-educating-for-design-design-discipline.md
+++ b/src/posts/2016-10-19-educating-for-design-design-discipline.md
@@ -1,5 +1,4 @@
 ---
-id: 108
 path: /posts/108-educating-for-design-design-discipline/
 title: "Educating for design: Design discipline"
 author: joao-ferreira

--- a/src/posts/2016-10-21-subvisual-weekly-13.md
+++ b/src/posts/2016-10-21-subvisual-weekly-13.md
@@ -1,5 +1,4 @@
 ---
-id: 115
 path: /posts/115-subvisual-weekly-13/
 title: "Subvisual Weekly #13"
 author: miguel-palhas

--- a/src/posts/2016-11-08-subvisual-weekly-14.md
+++ b/src/posts/2016-11-08-subvisual-weekly-14.md
@@ -1,5 +1,4 @@
 ---
-id: 116
 path: /posts/116-subvisual-weekly-14/
 title: "Subvisual Weekly #14"
 author: pedro-costa

--- a/src/posts/2016-11-18-the-trail-behind-me.md
+++ b/src/posts/2016-11-18-the-trail-behind-me.md
@@ -1,5 +1,4 @@
 ---
-id: 117
 path: /posts/117-the-trail-behind-me/
 title: "The Trail Behind Me"
 author: pedro-costa

--- a/src/posts/2016-12-16-open-files-on-existing-vim-sessions.md
+++ b/src/posts/2016-12-16-open-files-on-existing-vim-sessions.md
@@ -1,5 +1,4 @@
 ---
-id: 119
 path: /posts/119-open-files-on-existing-vim-sessions/
 title: "Open files on existing vim sessions"
 author: miguel-palhas

--- a/src/posts/2017-02-10-hakuna-matata.md
+++ b/src/posts/2017-02-10-hakuna-matata.md
@@ -1,5 +1,4 @@
 ---
-id: 121
 path: /posts/121-hakuna-matata/
 title: Hakuna Matata...
 author: laura-esteves

--- a/src/posts/2017-02-22-build-teams-of-incremental-learners.md
+++ b/src/posts/2017-02-22-build-teams-of-incremental-learners.md
@@ -1,5 +1,4 @@
 ---
-id: 122
 path: /posts/122-build-teams-of-incremental-learners/
 title: "Build Teams of Incremental Learners"
 author: roberto-machado

--- a/src/posts/2017-02-23-how-we-share-ownership-and-accountability.md
+++ b/src/posts/2017-02-23-how-we-share-ownership-and-accountability.md
@@ -1,5 +1,4 @@
 ---
-id: 123
 path: /posts/123-how-we-share-ownership-and-accountability/
 title: "How We Share Ownership and Accountability"
 author: roberto-machado

--- a/src/posts/2017-02-27-announcing-mirrorconf-2017-the-ultimate-digital-paradise.md
+++ b/src/posts/2017-02-27-announcing-mirrorconf-2017-the-ultimate-digital-paradise.md
@@ -1,5 +1,4 @@
 ---
-id: 124
 path: /posts/124-announcing-mirrorconf-2017-the-ultimate-digital-paradise/
 title: "Announcing MirrorConf 2017: the ultimate digital paradise"
 author: roberto-machado

--- a/src/posts/2017-03-03-subvisual-and-tnds-are-offering-a-design-sprint-apply-now.md
+++ b/src/posts/2017-03-03-subvisual-and-tnds-are-offering-a-design-sprint-apply-now.md
@@ -1,5 +1,4 @@
 ---
-id: 125
 path: /posts/125-subvisual-and-tnds-are-offering-a-design-sprint-apply-now/
 title: "Subvisual and TNDS are offering a Design Sprint - Apply now!"
 author: francisco-baila

--- a/src/posts/2017-03-07-the-pain-of-testing-with-3rd-party-integrations.md
+++ b/src/posts/2017-03-07-the-pain-of-testing-with-3rd-party-integrations.md
@@ -1,5 +1,4 @@
 ---
-id: 102
 path: /posts/102-the-pain-of-testing-with-3rd-party-integrations/
 title: "The pain of testing with 3rd party integrations"
 author: miguel-palhas

--- a/src/posts/2017-03-13-the-root-of-all-evil.md
+++ b/src/posts/2017-03-13-the-root-of-all-evil.md
@@ -1,5 +1,4 @@
 ---
-id: 126
 path: /posts/126-the-root-of-all-evil/
 title: "The root of all evil"
 author: miguel-palhas

--- a/src/posts/2017-03-15-stress-and-recovery-cycle.md
+++ b/src/posts/2017-03-15-stress-and-recovery-cycle.md
@@ -1,5 +1,4 @@
 ---
-id: 127
 path: /posts/127-stress-and-recovery-cycle/
 title: "Stress and Recovery Cycle"
 author: roberto-machado

--- a/src/posts/2017-03-17-rubyconf-portugal-gap-year.md
+++ b/src/posts/2017-03-17-rubyconf-portugal-gap-year.md
@@ -1,5 +1,4 @@
 ---
-id: 128
 path: /posts/128-rubyconf-portugal-gap-year/
 title: "RubyConf Portugal Gap Year"
 author: roberto-machado

--- a/src/posts/2017-03-22-product-vision-as-the-cornerstone.md
+++ b/src/posts/2017-03-22-product-vision-as-the-cornerstone.md
@@ -1,5 +1,4 @@
 ---
-id: 129
 path: /posts/129-product-vision-as-the-cornerstone/
 title: "Product Vision as the Cornerstone "
 author: roberto-machado

--- a/src/posts/2017-04-20-how-to-build-offline-web-applications-with-couchdb-and-pouchdb.md
+++ b/src/posts/2017-04-20-how-to-build-offline-web-applications-with-couchdb-and-pouchdb.md
@@ -1,5 +1,4 @@
 ---
-id: 130
 path: /posts/130-how-to-build-offline-web-applications-with-couchdb-and-pouchdb/
 title: "How to build offline web applications with CouchDB and PouchDB"
 author: gabriel-poca

--- a/src/posts/2017-04-24-design-sprints-and-the-academia.md
+++ b/src/posts/2017-04-24-design-sprints-and-the-academia.md
@@ -1,5 +1,4 @@
 ---
-id: 132
 path: /posts/132-design-sprints-and-the-academia/
 title: "Design Sprints and the Academia"
 author: fernando-mendes

--- a/src/posts/2017-04-28-super-powered-vim-part-i-projections.md
+++ b/src/posts/2017-04-28-super-powered-vim-part-i-projections.md
@@ -1,5 +1,4 @@
 ---
-id: 133
 path: /posts/133-super-powered-vim-part-i-projections/
 title: "Super-powered Vim, part I: Projections"
 author: miguel-palhas

--- a/src/posts/2017-04-28-super-powered-vim-part-ii-snippets.md
+++ b/src/posts/2017-04-28-super-powered-vim-part-ii-snippets.md
@@ -1,5 +1,4 @@
 ---
-id: 134
 path: /posts/134-super-powered-vim-part-ii-snippets/
 title: "Super-powered Vim, part II: Snippets"
 author: miguel-palhas

--- a/src/posts/2017-04-28-super-powered-vim-part-iii-skeletons.md
+++ b/src/posts/2017-04-28-super-powered-vim-part-iii-skeletons.md
@@ -1,5 +1,4 @@
 ---
-id: 135
 path: /posts/135-super-powered-vim-part-iii-skeletons/
 title: "Super-powered Vim, part III: Skeletons"
 author: miguel-palhas

--- a/src/posts/2017-05-04-how-to-run-usability-tests-with-small-teams-crediflux.md
+++ b/src/posts/2017-05-04-how-to-run-usability-tests-with-small-teams-crediflux.md
@@ -1,5 +1,4 @@
 ---
-id: 136
 path: /posts/136-how-to-run-usability-tests-with-small-teams-crediflux/
 title: "How to run Usability Tests with small teams: Crediflux"
 author: joao-ferreira

--- a/src/posts/2017-05-24-tutorial-deploying-elixir-applications-with-docker-and-digital-ocean.md
+++ b/src/posts/2017-05-24-tutorial-deploying-elixir-applications-with-docker-and-digital-ocean.md
@@ -1,5 +1,4 @@
 ---
-id: 137
 path: /posts/137-tutorial-deploying-elixir-applications-with-docker-and-digital-ocean/
 title: "Tutorial: Deploying Elixir applications with Docker and Digital Ocean"
 author: miguel-palhas

--- a/src/posts/2017-06-06-typography-as-base-from-the-content-out.md
+++ b/src/posts/2017-06-06-typography-as-base-from-the-content-out.md
@@ -1,5 +1,4 @@
 ---
-id: 138
 path: /posts/138-typography-as-base-from-the-content-out/
 title: "Typography as Base: From the Content Out"
 author: francisco-baila

--- a/src/posts/2017-09-04-how-to-program-vim-using-ruby.md
+++ b/src/posts/2017-09-04-how-to-program-vim-using-ruby.md
@@ -1,5 +1,4 @@
 ---
-id: 139
 path: /posts/139-how-to-program-vim-using-ruby/
 title: "How to program Vim using Ruby"
 author: gabriel-poca

--- a/src/posts/2017-12-18-continuous-integration-at-subvisual.md
+++ b/src/posts/2017-12-18-continuous-integration-at-subvisual.md
@@ -1,5 +1,4 @@
 ---
-id: 140
 path: /posts/140-continuous-integration-at-subvisual/
 title: "Continuous Integration at Subvisual"
 author: miguel-palhas

--- a/src/posts/2018-06-01-summer-camp-2018.md
+++ b/src/posts/2018-06-01-summer-camp-2018.md
@@ -1,5 +1,4 @@
 ---
-id: 141
 path: /posts/141-summer-camp-2018/
 title: "Subvisual's Summer Camp"
 author: helena-muniz

--- a/src/posts/2018-10-02-mirror-conf-2018.md
+++ b/src/posts/2018-10-02-mirror-conf-2018.md
@@ -1,5 +1,4 @@
 ---
-id: 142
 path: /posts/142-mirror-conf-2018/
 title: "Mirror Conf 2018"
 author: laura-esteves

--- a/src/posts/2019-02-02-its-not-continuous-delivery-yet.md
+++ b/src/posts/2019-02-02-its-not-continuous-delivery-yet.md
@@ -1,5 +1,4 @@
 ---
-id: 143
 path: /posts/143-its-not-continuous-delivery-yet/
 title: "It's not Continuous Delivery (yet)"
 author: pedro-costa

--- a/src/posts/2020-01-15-upsert-statements-with-ecto.md
+++ b/src/posts/2020-01-15-upsert-statements-with-ecto.md
@@ -1,5 +1,4 @@
 ---
-id: 145
 path: /posts/145-upsert-statements-with-ecto/
 title: "Upsert statements with Ecto"
 author: luis-zamith

--- a/src/posts/2020-02-10-subvisual-is-hiring-a-frontend-developer.md
+++ b/src/posts/2020-02-10-subvisual-is-hiring-a-frontend-developer.md
@@ -1,5 +1,4 @@
 ---
-id: 146
 path: /posts/146-subvisual-is-hiring-a-frontend-developer/
 title: Subvisual is hiring a Front End Developer
 author: roberto-machado

--- a/src/posts/2020-04-16-continuous-stuff-with-github-actions/index.md
+++ b/src/posts/2020-04-16-continuous-stuff-with-github-actions/index.md
@@ -1,5 +1,4 @@
 ---
-id: 148
 path: /posts/continuous-stuff-with-github-actions
 title: "Continuous Stuff with Github Actions"
 author: miguel-palhas

--- a/src/posts/2020-04-16-plug-based-authorisation-for-elixir-and-phoenix.md
+++ b/src/posts/2020-04-16-plug-based-authorisation-for-elixir-and-phoenix.md
@@ -1,5 +1,4 @@
 ---
-id: 147
 path: /posts/147-plug-based-authorisation-for-elixir/
 title: Plug-based authorisation for Elixir and Phoenix
 author: fernando-mendes

--- a/src/posts/2020-04-17-announcing-subvisual-live-talks/index.md
+++ b/src/posts/2020-04-17-announcing-subvisual-live-talks/index.md
@@ -1,5 +1,4 @@
 ---
-id: 148
 path: /posts/announcing-subvisual-live-talks/
 title: "Announcing Subvisual Live Talks: Zamith, Josh Clayton, Saša Jurić and others"
 author: fernando-mendes

--- a/src/templates/blog/author.js
+++ b/src/templates/blog/author.js
@@ -21,7 +21,6 @@ export const query = graphql`
         node {
           frontmatter {
             date
-            id
             intro
             path
             title
@@ -64,9 +63,9 @@ export default ({ data }) => {
   const { name: authorName, bio: authorBio } = authorYaml
   const posts = edges.map(({ node }) => {
     const { frontmatter } = node
-    const { date, id, intro, path, title } = frontmatter
+    const { date, intro, path, title } = frontmatter
 
-    return { date: new Date(date), id, intro, path, title }
+    return { date: new Date(date), intro, path, title }
   })
 
   return <BlogAuthorTemplate {...{ authorName, authorBio, posts }} />


### PR DESCRIPTION
Why:

* The first version of the Subvisual blog was created using Ruby on
  Rails. Back then, the path for each blog post was defined to be the
  [parameterize]d version of the blog post's title, prefixed by the
  post's numerical ID. The posts were stored in a database using
  auto-generated sequential numeric values.

  Each post has its own ID, but posts were not guaranteed to be
  published following this order, since the blog allowed for drafts.
  Drafts were just unpublished posts, but they had an ID to ensure
  persistence in the database.

  When the blog was migrated to GatsbyJS, the posts were all exported as
  Markdown files, retaining the ID of each post in the frontmatter.
  However this ID no longer has any purpose, neither as a field nor in
  the post's path.

This change addresses the issue by:

* Removing the ID fields from all blog posts;
* Refactoring the existing components and blog post page generation
  logic to drop the use of the `id` field.

[parameterize]: https://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-parameterize