### PR TITLE
Fixing site description

### DIFF
--- a/config/site_metadata.js
+++ b/config/site_metadata.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: "Subvisual",
-  description: "We nurture ıdeas that empower people",
+  description: "We nurture ideas that empower people",
   url: "https://subvisual.com",
   image: "/images/meta-image.jpg",
   twitterUsername: "@subvisual",


### PR DESCRIPTION
As far as I can tell, this dotless-i thing is no longer used
This `siteMetadata.description` is only used for SEO. The title string
is hardcoded, due to the weird animation needs going on, and the
dotless-i is achieved using a specific font instead of a different
character