### PR TITLE
Fix drop cap in posts with a pre-message

### DIFF
--- a/src/components/blog/post/body.module.scss
+++ b/src/components/blog/post/body.module.scss
@@ -45,21 +45,21 @@
     }
   }
 
-  &.macos > p:first-child::first-letter {
+  &.macos > p:first-of-type::first-letter {
     @-moz-document url-prefix() {
       margin-top: 10px;
     }
   }
 
-  &.macos.chrome > p:first-child::first-letter {
+  &.macos.chrome > p:first-of-type::first-letter {
     margin-top: 6px;
   }
 
-  &.safari > p:first-child::first-letter {
+  &.safari > p:first-of-type::first-letter {
     margin-top: 2px;
   }
 
-  &.edge > p:first-child::first-letter {
+  &.edge > p:first-of-type::first-letter {
     margin-top: 4px;
   }
 }


### PR DESCRIPTION
Why:

* https://subvisual.com/blog/posts/continuous-stuff-with-github-actions

  The drop cap in this post is misplaced in some browsers, because #306
  changed the main CSS rule for the drop cap to apply to the first `p`
  tag instead of the first child, but did not change the system-specific
  styles accordingly.

This change addresses the issue by:

* Changing all drop cap styles to apply to the first `p` tag.