### PR TITLE
Fix image placement in blog posts

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -73,7 +73,6 @@ module.exports = [
           },
         },
         "gatsby-remark-responsive-iframe",
-        "gatsby-remark-unwrap-images",
       ],
     },
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "gatsby-remark-images": "^3.2.2",
     "gatsby-remark-prismjs": "^3.4.1",
     "gatsby-remark-responsive-iframe": "^2.3.1",
-    "gatsby-remark-unwrap-images": "^1.0.1",
     "gatsby-source-filesystem": "^2.0.23",
     "gatsby-transformer-remark": "^2.6.15",
     "gatsby-transformer-sharp": "^2.1.14",

--- a/src/components/blog/post/body.module.scss
+++ b/src/components/blog/post/body.module.scss
@@ -1,3 +1,5 @@
+@import "common/breakpoints";
+
 .root {
   @import "./body/anchor";
   @import "./body/blockquote";
@@ -61,5 +63,23 @@
 
   &.edge > p:first-of-type::first-letter {
     margin-top: 4px;
+  }
+
+  /* Image placement */
+
+  & > p > img,
+  & > p > :global(.gatsby-resp-image-wrapper) {
+    position: relative;
+    left: 50%;
+
+    display: block;
+    width: 100vw;
+    max-width: 762px;
+
+    transform: translateX(-50%);
+
+    @include media(">=desktop") {
+      max-width: 834px;
+    }
   }
 }

--- a/src/components/blog/post/body/_image.scss
+++ b/src/components/blog/post/body/_image.scss
@@ -5,14 +5,3 @@ img {
     margin: 56px 0;
   }
 }
-
-img:not(:global .gatsby-resp-image-image) {
-  position: relative;
-  left: 50%;
-
-  display: block;
-  width: auto;
-  max-width: 100%;
-
-  transform: translateX(-50%);
-}

--- a/src/components/blog/post/body/_paragraph.scss
+++ b/src/components/blog/post/body/_paragraph.scss
@@ -2,6 +2,8 @@
 
 p,
 :global(.BlogPostParagraph) {
+  position: relative;
+
   max-width: $BlogPostBody-text-maxWidth-mobile;
   padding: 0 20px;
   margin: 20px auto 28px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6144,14 +6144,6 @@ gatsby-remark-responsive-iframe@^2.3.1:
     lodash "^4.17.15"
     unist-util-visit "^1.4.1"
 
-gatsby-remark-unwrap-images@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/gatsby-remark-unwrap-images/-/gatsby-remark-unwrap-images-1.0.1.tgz#180472da9e016a127e00eb3a26d4c7370e9d7184"
-  integrity sha512-qBj4PDez/TrAOX/gWtRvklUotT7yYikPvN1XYYDR4PECM9ky1gXIGc1/jqYlLCTja70vgWTHxzPptkRpgw+o4g==
-  dependencies:
-    unist-util-remove "^1.0.1"
-    unist-util-visit "^1.4.0"
-
 gatsby-source-filesystem@^2.0.23:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.35.tgz#b0ae2de06b1100fa9f48e79a2f290e5a82d2d4ff"
@@ -13890,13 +13882,6 @@ unist-util-remove-position@^1.0.0, unist-util-remove-position@^1.1.3:
   dependencies:
     unist-util-visit "^1.1.0"
 
-unist-util-remove@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/unist-util-remove/-/unist-util-remove-1.0.3.tgz#58ec193dfa84b52d5a055ffbc58e5444eb8031a3"
-  integrity sha512-mB6nCHCQK0pQffUAcCVmKgIWzG/AXs/V8qpS8K72tMPtOSCMSjDeMc5yN+Ye8rB0FhcE+JvW++o1xRNc0R+++g==
-  dependencies:
-    unist-util-is "^3.0.0"
-
 unist-util-select@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/unist-util-select/-/unist-util-select-1.5.0.tgz#a93c2be8c0f653827803b81331adec2aa24cd933"
@@ -13931,7 +13916,7 @@ unist-util-visit-parents@^3.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
 
-unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.1.3, unist-util-visit@^1.4.0, unist-util-visit@^1.4.1:
+unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.1.3, unist-util-visit@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
   integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==


### PR DESCRIPTION
Why:

* #305 added `gatsby-remark-images` which places images inside a
  paragraph with a wrapper around it. Images added this way do not
  assume the placement devised in #257.
* The placement devised in #257 relies on `gatsby-remark-unwrap-images`,
  which removes the paragraph tag around the image. This made it easier
  to place the images since there was no need to circumvent the styles
  applied to regular text-only paragraphs.

This change addresses the issues by:

* Removing `gatsby-remark-unwrap-images`;
* Refactoring the image placement styles to unify images from remote
  sources and images from the local filesystem (and thus processed by
  `gatsby-remark-images`).