### PR TITLE
Fix blog post image width

### DIFF
--- a/src/components/blog/post/_variables.scss
+++ b/src/components/blog/post/_variables.scss
@@ -1,0 +1,5 @@
+/* Post body max-width, which is the value in the design + the side paddings
+ * required to keep things responsive.
+ */
+$BlogPost-body-maxWidth-mobile: 818px;
+$BlogPost-body-maxWidth-desktop: 834px;

--- a/src/components/blog/post/body.module.scss
+++ b/src/components/blog/post/body.module.scss
@@ -1,5 +1,7 @@
 @import "common/breakpoints";
 
+@import "./variables";
+
 .root {
   @import "./body/anchor";
   @import "./body/blockquote";
@@ -74,12 +76,12 @@
 
     display: block;
     width: 100vw;
-    max-width: 762px;
+    max-width: $BlogPost-body-maxWidth-mobile !important; /* override inline styles */
 
     transform: translateX(-50%);
 
     @include media(">=desktop") {
-      max-width: 834px;
+      max-width: $BlogPost-body-maxWidth-desktop !important; /* override inline styles */
     }
   }
 }


### PR DESCRIPTION
Why:

* `gatsby-remark-images` places the images in the blog posts using
  inline styles, where it automatically sets the maximum width to the
  value in the plugin configuration. However, we want this value to be
  slightly smaller below the desktop breakpoint, since the grid gaps
  also become smaller.

This change addresses the issue by:

* Overriding the inline styles in the images styles by using
  `!important`, setting the maximum width responsively.