### PR TITLE
Realign blog post block quotes

### DIFF
--- a/src/common/utils/_interpolate.scss
+++ b/src/common/utils/_interpolate.scss
@@ -1,0 +1,37 @@
+@use "sass:math";
+
+/** Interpolate the values of a property in a range of the viewport width.
+ *
+ * The design only covers the minimum and maximum viewport sizes. While spaces
+ * collapse to absorb the growth of the viewport, in some specific points the
+ * rules are not set. So, instead of jumping straight from one position to the
+ * other, this function allows us to gradually transition between the two
+ * states.
+ */
+@mixin interpolate(
+  $property,
+  $from,
+  $to,
+  $start,
+  $end,
+  $before: $start,
+  $after: $end
+) {
+  #{$property}: $before;
+
+  @media (min-width: #{$from}) {
+    $base: min($start, $end);
+    $multiplier: abs($end - $start) / abs($to - $from);
+
+    /* CSS calc() expressions don't accept additions with unitless zeros */
+    @if $base == 0 {
+      #{$property}: calc((#{$to} - 100vw) * #{$multiplier});
+    } @else {
+      #{$property}: calc(#{$base} + (#{$to} - 100vw) * #{$multiplier});
+    }
+  }
+
+  @media (min-width: #{$to}) {
+    #{$property}: $after;
+  }
+}

--- a/src/components/blog/post/body/_blockquote.scss
+++ b/src/components/blog/post/body/_blockquote.scss
@@ -1,4 +1,5 @@
 @import "common/breakpoints";
+@import "common/utils/interpolate";
 
 @import "./variables";
 
@@ -6,17 +7,21 @@ blockquote {
   position: relative;
 
   max-width: $BlogPostBody-text-maxWidth-mobile;
-  padding: 20px 20px 0;
-  margin: 56px auto 40px 0;
+  padding-top: 20px;
+  margin: 56px auto 40px;
 
   font-family: "Acta Headline", serif;
   font-size: 20px;
   font-weight: 800;
   line-height: 28px;
 
+  @include interpolate("padding-right", 718px, 758px, 20px, 0);
+  @include interpolate("padding-left", 818px, 858px, 20px, 0);
+  @include interpolate("margin-left", 818px, 858px, 50px, 0, auto);
+
   @include media(">=desktop") {
     max-width: $BlogPostBody-text-maxWidth-desktop;
-    padding: 28px 28px 0 28px;
+    padding: 28px 0 0;
     margin: 78px auto 56px 0;
 
     font-size: 28px;
@@ -42,6 +47,8 @@ blockquote {
     font-size: 56px;
     font-weight: normal;
     line-height: 56px;
+
+    @include interpolate("left", 818px, 858px, 95px, 70px);
 
     @include media(">=desktop") {
       top: -34px;
@@ -70,8 +77,9 @@ blockquote {
   }
 
   p:last-child:not(:first-child) {
-    width: calc(100% - 72px);
-    max-width: 506px;
+    position: relative;
+    left: 75px;
+
     margin-left: auto;
 
     font-family: colfax-web, sans-serif;
@@ -79,8 +87,18 @@ blockquote {
     font-weight: 500;
     line-height: 20px;
 
+    @include interpolate("left", 818px, 858px, 75px, 70px);
+
+    @include media(">=818px") {
+      left: calc(70px + (858px - 100vw) * 0.125);
+    }
+
+    @include media(">=858px") {
+      left: 70px;
+    }
+
     @include media(">=desktop") {
-      max-width: 478px;
+      left: 78px;
 
       font-size: 20px;
       line-height: 28px;


### PR DESCRIPTION
Why:

* #296 changed the width of the paragraphs in blog posts, which caused
  block quotes to become misaligned.

This change addresses the need by:

* Adding an interpolation Sass mixin, to cover for cases where a
  property must have a dynamic value between two breakpoints, allowing
  the styles to be completely responsive without unnecessary jumps;
* Realigning the blockquote parts to align with the new text width with
  full responsiveness.

Before:
![2020-04-23_15-09](https://user-images.githubusercontent.com/1141870/80200936-464e5880-861b-11ea-80de-5c137638cc52.png)

After:
![2020-04-24_11-04](https://user-images.githubusercontent.com/1141870/80200982-57976500-861b-11ea-84c5-31ab5fcaa609.png)
