### PR TITLE
Upgrade intersection observer polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "gatsby-transformer-sharp": "^2.1.14",
     "gatsby-transformer-yaml": "^2.1.10",
     "include-media": "^1.4.9",
-    "intersection-observer": "0.7.0",
+    "intersection-observer": "0.10.0",
     "lodash": "^4.17.15",
     "popmotion": "^8.6.10",
     "postcss-url": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7509,10 +7509,10 @@ internal-ip@^4.3.0:
     default-gateway "^4.2.0"
     ipaddr.js "^1.9.0"
 
-intersection-observer@0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.7.0.tgz#ee16bee978db53516ead2f0a8154b09b400bbdc9"
-  integrity sha512-Id0Fij0HsB/vKWGeBe9PxeY45ttRiBmhFyyt/geBdDHBYNctMRTE3dC1U3ujzz3lap+hVXlEcVaB56kZP/eEUg==
+intersection-observer@0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.10.0.tgz#4d11d63c1ff67e21e62987be24d55218da1a1a69"
+  integrity sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==
 
 into-stream@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
`yarn outdated` says it's outdated. This fixes that.