### PR TITLE
Add support for file paths in blog post covers

### DIFF
--- a/config/node/create_pages.js
+++ b/config/node/create_pages.js
@@ -22,7 +22,7 @@ const createBlogAuthorsPages = async ({ createPage, graphql }) => {
   `
   const results = await graphql(query)
 
-  results.data.allMarkdownRemark.distinct.forEach(authorKey =>
+  results.data.allMarkdownRemark.distinct.forEach((authorKey) =>
     createPage({
       component,
       context: { authorKey, blogPostsPathRegex: `/^${basePath}/` },
@@ -39,19 +39,30 @@ const createBlogPostsPages = async ({ createPage, graphql }) => {
       allMarkdownRemark(
         filter: { fileAbsolutePath: { regex: "/^${basePath}/" } }
       ) {
-        distinct(field: frontmatter___path)
+        nodes {
+          fields {
+            cover
+          }
+          frontmatter {
+            path
+          }
+        }
       }
     }
   `
   const results = await graphql(query)
 
-  results.data.allMarkdownRemark.distinct.forEach(slug =>
+  results.data.allMarkdownRemark.nodes.forEach((node) => {
+    const { fields, frontmatter } = node
+    const { cover } = fields
+    const { path: slug } = frontmatter
+
     createPage({
       component,
-      context: { slug },
+      context: { cover, slug },
       path: path.posix.join("/blog", slug),
     })
-  )
+  })
 }
 
 module.exports = async ({ actions, graphql }) => {

--- a/config/node/create_schema_customization.js
+++ b/config/node/create_schema_customization.js
@@ -16,6 +16,7 @@ module.exports = ({ actions }) => {
 
       type Frontmatter {
         author: Author! @link(by: "key"),
+        cover: String,
         date: Date!,
         path: String!,
         tags: [String]!,

--- a/config/node/on_create_node.js
+++ b/config/node/on_create_node.js
@@ -1,0 +1,33 @@
+const path = require("path")
+const isString = require("lodash/isString")
+
+const { isURL } = require("../../src/utils/url_utils")
+
+const resolveBlogPostCover = ({ cover, node }) => {
+  const { fileAbsolutePath } = node
+
+  if (isURL(cover) || path.isAbsolute(cover)) return cover
+
+  const dirname = path.dirname(fileAbsolutePath)
+
+  return path.resolve(dirname, cover)
+}
+
+const prepareBlogPostCover = ({ node }) => {
+  const { frontmatter } = node
+  const { cover } = frontmatter
+
+  if (isString(cover)) return resolveBlogPostCover({ cover, node })
+
+  return cover
+}
+
+module.exports = async ({ node, actions }) => {
+  // Skip this logic unless the node was created by processing a markdown file
+  if (node.internal.type !== "MarkdownRemark") return
+
+  const { createNodeField } = actions
+  const cover = prepareBlogPostCover({ node, actions })
+
+  createNodeField({ node, name: "cover", value: cover })
+}

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,2 +1,3 @@
 exports.createPages = require("./config/node/create_pages")
 exports.createSchemaCustomization = require("./config/node/create_schema_customization")
+exports.onCreateNode = require("./config/node/on_create_node")

--- a/src/components/blog/post/header.js
+++ b/src/components/blog/post/header.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types"
 import { Link } from "gatsby"
 import dateFormat from "dateformat"
 
+import Cover from "./header/cover"
 import Title from "../title"
 import Wrapper from "./wrapper"
 
@@ -14,21 +15,18 @@ const renderAuthor = ({ key, name }) => (
   </>
 )
 
-const BlogPostHeader = ({ author, date, cover, title }) => {
+const renderCover = ({ cover, coverFile }) => {
+  if (!coverFile && !cover) return null
+
+  return (
+    <Wrapper>
+      <Cover {...{ className: styles.cover, cover, coverFile }} />
+    </Wrapper>
+  )
+}
+
+const BlogPostHeader = ({ author, cover, coverFile, date, title }) => {
   const formattedDate = dateFormat(date, "mmmm d, yyyy")
-
-  const renderCover = () => {
-    if (!cover) return null
-
-    return (
-      <Wrapper>
-        <div
-          className={styles.cover}
-          style={{ backgroundImage: `url(${cover})` }}
-        />
-      </Wrapper>
-    )
-  }
 
   return (
     <>
@@ -37,7 +35,7 @@ const BlogPostHeader = ({ author, date, cover, title }) => {
           <Title>{title}</Title>
         </div>
       </Wrapper>
-      {renderCover()}
+      {renderCover({ cover, coverFile })}
       <Wrapper padded>
         <div className={styles.info}>
           <span className={styles.author}>{renderAuthor(author)}</span>
@@ -53,8 +51,9 @@ BlogPostHeader.propTypes = {
     key: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
   }).isRequired,
-  date: PropTypes.instanceOf(Date).isRequired,
   cover: PropTypes.string,
+  coverFile: PropTypes.object,
+  date: PropTypes.instanceOf(Date).isRequired,
   title: PropTypes.string.isRequired,
 }
 

--- a/src/components/blog/post/header.module.css
+++ b/src/components/blog/post/header.module.css
@@ -6,12 +6,8 @@
   width: 100%;
   height: 100vw;
   max-width: 980px; /* 10 columns + 9 gutters */
-  max-height: 50vh;
+  max-height: 452px;
   margin-bottom: 40px;
-
-  background-position: center bottom;
-  background-size: cover;
-  filter: grayscale(100%);
 }
 
 .info {

--- a/src/components/blog/post/header/cover.js
+++ b/src/components/blog/post/header/cover.js
@@ -1,0 +1,37 @@
+import React from "react"
+import PropTypes from "prop-types"
+import Img from "gatsby-image"
+import classNames from "classnames"
+
+import styles from "./cover.module.scss"
+
+const renderFluidCover = ({ className, coverFile }) => {
+  const {
+    childImageSharp: { fluid },
+  } = coverFile
+
+  return <Img {...{ className, fluid }} />
+}
+
+const BlogPostHeaderCover = ({ className, cover, coverFile }) => {
+  const rootClassName = classNames(styles.root, className)
+
+  if (coverFile) {
+    return renderFluidCover({ className: rootClassName, coverFile })
+  }
+
+  return (
+    <div
+      className={rootClassName}
+      style={{ backgroundImage: `url(${cover})` }}
+    />
+  )
+}
+
+BlogPostHeaderCover.propTypes = {
+  className: PropTypes.string,
+  cover: PropTypes.string,
+  coverFile: PropTypes.object,
+}
+
+export default BlogPostHeaderCover

--- a/src/components/blog/post/header/cover.module.scss
+++ b/src/components/blog/post/header/cover.module.scss
@@ -1,0 +1,5 @@
+.root {
+  background-position: center bottom;
+  background-size: cover;
+  filter: grayscale(100%);
+}

--- a/src/templates/blog/post.js
+++ b/src/templates/blog/post.js
@@ -28,7 +28,7 @@ export const query = graphql`
     }
     coverFile: file(absolutePath: { eq: $cover }) {
       childImageSharp {
-        fluid(maxWidth: 980) {
+        fluid(grayscale: true, maxWidth: 980) {
           ...GatsbyImageSharpFluid
         }
       }

--- a/src/templates/blog/post.js
+++ b/src/templates/blog/post.js
@@ -11,29 +11,38 @@ import "../../common/base.scss"
 import styles from "./post.module.scss"
 
 export const query = graphql`
-  query($slug: String!) {
+  query($cover: String, $slug: String!) {
     markdownRemark(frontmatter: { path: { eq: $slug } }) {
-      html
+      fields {
+        cover
+      }
       frontmatter {
         author {
           key
           name
         }
         date
-        cover
         title
+      }
+      html
+    }
+    coverFile: file(absolutePath: { eq: $cover }) {
+      childImageSharp {
+        fluid(maxWidth: 980) {
+          ...GatsbyImageSharpFluid
+        }
       }
     }
   }
 `
 
-const BlogPostTemplate = ({ author, date, html, cover, title }) => (
+const BlogPostTemplate = ({ author, cover, coverFile, date, html, title }) => (
   <Layout>
     <SEO title={title} />
     <div className={styles.root}>
       <article className={styles.article}>
         <header className={styles.header}>
-          <Header {...{ author, date, cover, title }} />
+          <Header {...{ author, cover, coverFile, date, title }} />
         </header>
         <section className={styles.body}>
           <Body html={html} />
@@ -48,17 +57,26 @@ BlogPostTemplate.propTypes = {
   date: PropTypes.instanceOf(Date).isRequired,
   html: PropTypes.string.isRequired,
   cover: PropTypes.string,
+  coverFile: PropTypes.object,
   title: PropTypes.string.isRequired,
 }
 
 export default ({ data }) => {
-  const { markdownRemark } = data
-  const { frontmatter, html } = markdownRemark
-  const { author, date, cover, title } = frontmatter
+  const { markdownRemark, coverFile } = data
+  const { fields, frontmatter, html } = markdownRemark
+  const { cover } = fields
+  const { author, date, title } = frontmatter
 
   return (
     <BlogPostTemplate
-      {...{ author, date: new Date(date), html, cover, title }}
+      {...{
+        author,
+        date: new Date(date),
+        html,
+        cover,
+        coverFile,
+        title,
+      }}
     />
   )
 }

--- a/src/utils/url_utils.js
+++ b/src/utils/url_utils.js
@@ -1,0 +1,12 @@
+const isURL = (string) => {
+  try {
+    /* eslint-disable-next-line no-new */
+    new URL(string)
+  } catch {
+    return false
+  }
+
+  return true
+}
+
+module.exports = { isURL }


### PR DESCRIPTION
Why:

* Following #305, where we added the ability to reference images in the
  local filesystem in the blog post Markdown body, our blog posts can
  now be self contained, with the required images sitting next to the
  blog post;
* That did not cover the blog post covers though (pun intended), which
  are expected to be URLs in the blog post frontmatter.

This change addresses the issue by:

* Post-processing all nodes created by Markdown files and adding a
  `cover` node field, which is the cover URL or a path, resolving it
  into an absolute path from the Markdown file directory;
* Passing the new field to the page creation context, allowing to use
  this field to locate the image file in GraphQL;
* Refactoring the blog post template to extract the cover file sharp
  fragment and pass it down to the blog post header;
* Adding a blog post header cover component which renders a fluid cover
  if a file was found in the local filesystem, and keeps the current
  approach assuming an external URL otherwise.

Note: this change was devised in #324 and can be previewed in
https://deploy-preview-324--subvisual.netlify.app/blog/posts/apprenticeship-and-summer-camp-programs/