### PR TITLE
Fix blog post mobile text width

### DIFF
--- a/src/components/blog/post/body/_blockquote.scss
+++ b/src/components/blog/post/body/_blockquote.scss
@@ -14,12 +14,12 @@ blockquote {
   font-weight: 800;
   line-height: 28px;
 
-  @include media(">=628px") {
+  @include media(">=668px") {
     max-width: $BlogPostBody-text-maxWidth-mobile + (56px + 20px) * 2;
   }
 
   @include media(">=818px") {
-    margin-left: 95px;
+    margin-left: 75px;
   }
 
   @include media(">=desktop") {

--- a/src/components/blog/post/body/_variables.scss
+++ b/src/components/blog/post/body/_variables.scss
@@ -1,5 +1,5 @@
 /* Text width max-width, which is the value in the design + the side paddings
  * required to keep things responsive.
  */
-$BlogPostBody-text-maxWidth-mobile: 476px;
+$BlogPostBody-text-maxWidth-mobile: 516px;
 $BlogPostBody-text-maxWidth-desktop: 734px;


### PR DESCRIPTION
Why:

* I forgot to consider the side padding in #334. :grimacing:

This change addresses the issue by:

* Fixing the text width max size considering the side padding;
* Adjusting the blockquote elements positioning to the new width.