### PR TITLE
Fix blog post URL generation

### DIFF
--- a/config/node/on_create_node.js
+++ b/config/node/on_create_node.js
@@ -4,7 +4,7 @@ const isUndefined = require("lodash/isUndefined")
 
 const { isURL } = require("../../src/utils/url_utils")
 
-const { NODE_ENV, URL } = process.env
+const { NODE_ENV } = process.env
 
 const resolveBlogPostCover = ({ cover, node }) => {
   const { fileAbsolutePath } = node
@@ -33,9 +33,12 @@ const prepareBlogPostUrl = ({ node }) => {
     `)
   }
 
-  const root = isString(URL) ? URL : "http://localhost:8000"
+  const urlBase = isURL(process.env.URL)
+    ? process.env.URL
+    : "http://localhost:8000"
+  const urlPath = path.posix.join("/blog", node.frontmatter.path)
 
-  return path.posix.join(root, "blog", node.frontmatter.path)
+  return new URL(urlPath, urlBase).toString()
 }
 
 module.exports = async ({ node, actions }) => {

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -17,7 +17,7 @@ const detailsQuery = graphql`
   }
 `
 
-function SEO({ description, lang, keywords, title }) {
+function SEO({ description, lang, keywords, title, url }) {
   return (
     <StaticQuery
       query={detailsQuery}
@@ -40,13 +40,19 @@ function SEO({ description, lang, keywords, title }) {
             <meta name="description" content={metaDescription} />
 
             <meta property="og:type" content="website" />
-            <meta property="og:url" content={data.site.siteMetadata.url} />
+            <meta
+              property="og:url"
+              content={url || data.site.siteMetadata.url}
+            />
             <meta property="og:title" content={metaTitle} />
             <meta property="og:description" content={metaDescription} />
             <meta property="og:image" content={metaImage} />
 
             <meta name="twitter:card" content="summary_large_image" />
-            <meta property="twitter:url" content={data.site.siteMetadata.url} />
+            <meta
+              property="twitter:url"
+              content={url || data.site.siteMetadata.url}
+            />
             <meta
               name="twitter:creator"
               content={data.site.siteMetadata.twitterUsername}
@@ -75,6 +81,7 @@ SEO.propTypes = {
   lang: PropTypes.string,
   keywords: PropTypes.arrayOf(PropTypes.string),
   title: PropTypes.string,
+  url: PropTypes.string,
 }
 
 export default SEO

--- a/src/templates/blog/post.js
+++ b/src/templates/blog/post.js
@@ -54,7 +54,7 @@ const BlogPostTemplate = ({
   seoDescription,
 }) => (
   <Layout>
-    <SEO {...{ title, description: seoDescription || intro }} />
+    <SEO {...{ title, description: seoDescription || intro, url }} />
     <div className={styles.root}>
       <article className={styles.article}>
         <header className={styles.header}>


### PR DESCRIPTION
Why:

* https://3.basecamp.com/4319812/buckets/16728109/todos/2849314582
  
  The blog post URL is being generated using the `path` tooling from
  Node.js, to ensure the slashes are placed as expected. However, `path`
  does not deal well with the double slashes in an URL's protocol, and
  is removing one of them, resulting in an invalid URL.
* We're always using the root URL for social networks metadata.

This change addresses the issue by:

* Replacing this logic with the proper use of the `URL` constructor;
* Using the blog post's URL instead of the root URL for social networks
  metadata, if available.