### PR TITLE
Ability to specify a meta-image for posts without a cover

### DIFF
--- a/config/node/create_pages.js
+++ b/config/node/create_pages.js
@@ -42,6 +42,7 @@ const createBlogPostsPages = async ({ createPage, graphql }) => {
         nodes {
           fields {
             cover
+            seoImage
           }
           frontmatter {
             path
@@ -54,12 +55,12 @@ const createBlogPostsPages = async ({ createPage, graphql }) => {
 
   results.data.allMarkdownRemark.nodes.forEach((node) => {
     const { fields, frontmatter } = node
-    const { cover } = fields
+    const { cover, seoImage } = fields
     const { path: slug } = frontmatter
 
     createPage({
       component,
-      context: { cover, slug },
+      context: { cover, seoImage, slug },
       path: path.posix.join("/blog", slug),
     })
   })

--- a/config/node/create_schema_customization.js
+++ b/config/node/create_schema_customization.js
@@ -22,6 +22,7 @@ module.exports = ({ actions }) => {
         tags: [String]!,
         title: String!,
         seoDescription: String,
+        seoImage: String,
       }
 
       type MarkdownRemark implements Node {

--- a/config/node/on_create_node.js
+++ b/config/node/on_create_node.js
@@ -16,6 +16,16 @@ const resolveBlogPostCover = ({ cover, node }) => {
   return path.resolve(dirname, cover)
 }
 
+const resolveBlogPostSEOImage = ({ seoImage, node }) => {
+  const { fileAbsolutePath } = node
+
+  if (isURL(seoImage) || path.isAbsolute(seoImage)) return seoImage
+
+  const dirname = path.dirname(fileAbsolutePath)
+
+  return path.resolve(dirname, seoImage)
+}
+
 const prepareBlogPostCover = ({ node }) => {
   const { frontmatter } = node
   const { cover } = frontmatter
@@ -23,6 +33,15 @@ const prepareBlogPostCover = ({ node }) => {
   if (isString(cover)) return resolveBlogPostCover({ cover, node })
 
   return cover
+}
+
+const prepareBlogPostSEOImage = ({ node }) => {
+  const { frontmatter } = node
+  const { seoImage } = frontmatter
+
+  if (isString(seoImage)) return resolveBlogPostSEOImage({ seoImage, node })
+
+  return seoImage
 }
 
 const prepareBlogPostUrl = ({ node }) => {
@@ -47,8 +66,10 @@ module.exports = async ({ node, actions }) => {
 
   const { createNodeField } = actions
   const cover = prepareBlogPostCover({ node })
+  const seoImage = prepareBlogPostSEOImage({ node })
   const url = prepareBlogPostUrl({ node })
 
   createNodeField({ node, name: "cover", value: cover })
+  createNodeField({ node, name: "seoImage", value: seoImage })
   createNodeField({ node, name: "url", value: url })
 }

--- a/src/posts/2020-02-23-apprenticeship-and-summer-camp-programs/index.md
+++ b/src/posts/2020-02-23-apprenticeship-and-summer-camp-programs/index.md
@@ -4,6 +4,7 @@ title: Apprenticeship and Summer Camp programs
 author: laura-esteves
 date: 2020-02-23
 cover: ./cover.png
+seoImage: ./cover.png
 tags:
   - general
 intro: >

--- a/src/templates/blog/post.js
+++ b/src/templates/blog/post.js
@@ -54,35 +54,31 @@ const BlogPostTemplate = ({
   intro,
   seoDescription,
   seoImage,
-}) => {
-  console.log(cover)
-  console.log(seoImage)
-  return (
-    <Layout>
-      <SEO
-        description={seoDescription || intro}
-        image={seoImage || cover}
-        title={title}
-        url={url}
-      />
-      <div className={styles.root}>
-        <article className={styles.article}>
-          <header className={styles.header}>
-            <Header {...{ author, cover, coverFile, date, title }} />
-          </header>
-          <section>
-            <Wrapper className={styles.outerWrapper}>
-              <BodyWrapper className={styles.innerWrapper}>
-                <Body html={html} />
-              </BodyWrapper>
-              <ShareLinks className={styles.shareLinks} url={url} />
-            </Wrapper>
-          </section>
-        </article>
-      </div>
-    </Layout>
-  )
-}
+}) => (
+  <Layout>
+    <SEO
+      description={seoDescription || intro}
+      image={seoImage || cover}
+      title={title}
+      url={url}
+    />
+    <div className={styles.root}>
+      <article className={styles.article}>
+        <header className={styles.header}>
+          <Header {...{ author, cover, coverFile, date, title }} />
+        </header>
+        <section>
+          <Wrapper className={styles.outerWrapper}>
+            <BodyWrapper className={styles.innerWrapper}>
+              <Body html={html} />
+            </BodyWrapper>
+            <ShareLinks className={styles.shareLinks} url={url} />
+          </Wrapper>
+        </section>
+      </article>
+    </div>
+  </Layout>
+)
 
 BlogPostTemplate.propTypes = {
   author: PropTypes.object.isRequired,

--- a/src/templates/blog/post.js
+++ b/src/templates/blog/post.js
@@ -18,6 +18,7 @@ export const query = graphql`
     markdownRemark(frontmatter: { path: { eq: $slug } }) {
       fields {
         cover
+        seoImage
         url
       }
       frontmatter {
@@ -52,35 +53,41 @@ const BlogPostTemplate = ({
   url,
   intro,
   seoDescription,
-}) => (
-  <Layout>
-    <SEO
-      description={seoDescription || intro}
-      image={cover}
-      title={title}
-      url={url}
-    />
-    <div className={styles.root}>
-      <article className={styles.article}>
-        <header className={styles.header}>
-          <Header {...{ author, cover, coverFile, date, title }} />
-        </header>
-        <section>
-          <Wrapper className={styles.outerWrapper}>
-            <BodyWrapper className={styles.innerWrapper}>
-              <Body html={html} />
-            </BodyWrapper>
-            <ShareLinks className={styles.shareLinks} url={url} />
-          </Wrapper>
-        </section>
-      </article>
-    </div>
-  </Layout>
-)
+  seoImage,
+}) => {
+  console.log(cover)
+  console.log(seoImage)
+  return (
+    <Layout>
+      <SEO
+        description={seoDescription || intro}
+        image={seoImage || cover}
+        title={title}
+        url={url}
+      />
+      <div className={styles.root}>
+        <article className={styles.article}>
+          <header className={styles.header}>
+            <Header {...{ author, cover, coverFile, date, title }} />
+          </header>
+          <section>
+            <Wrapper className={styles.outerWrapper}>
+              <BodyWrapper className={styles.innerWrapper}>
+                <Body html={html} />
+              </BodyWrapper>
+              <ShareLinks className={styles.shareLinks} url={url} />
+            </Wrapper>
+          </section>
+        </article>
+      </div>
+    </Layout>
+  )
+}
 
 BlogPostTemplate.propTypes = {
   author: PropTypes.object.isRequired,
   cover: PropTypes.string,
+  seoImage: PropTypes.string,
   coverFile: PropTypes.object,
   date: PropTypes.instanceOf(Date).isRequired,
   html: PropTypes.string.isRequired,
@@ -92,7 +99,7 @@ BlogPostTemplate.propTypes = {
 export default ({ data }) => {
   const { markdownRemark, coverFile } = data
   const { fields, frontmatter, html } = markdownRemark
-  const { cover, url } = fields
+  const { seoImage, cover, url } = fields
   const { author, date, title, intro, seoDescription } = frontmatter
 
   return (
@@ -105,6 +112,7 @@ export default ({ data }) => {
         html,
         intro,
         seoDescription,
+        seoImage,
         title,
         url,
       }}


### PR DESCRIPTION
Most of our posts nowadays don't have a cover image.  That leads to the preview
on social media being a default banner from the homepage, which tells nothing
about the post itself.

As a monkey patch, Laura and Baila have been manually creating images for each
post, after-the-fact (e.g.:
https://twitter.com/subvisual/status/1286280282354655234)

Not only is this laborious, it also works against social engagement, because
the tweet now consists of a link + image. The image itself is not a link to the
post, making the experience confusing (and frankly, I wouldn't be surprised if
we got less views over this)

This PR allows us to specify a `seoImage` in each post, which will be used for social media,
without the need for a cover existing on the post

(This will tie in nicely with the PR draft I'm about to open in a few seconds)