### PR TITLE
Fix SEO title

### DIFF
--- a/src/components/SEO/index.jsx
+++ b/src/components/SEO/index.jsx
@@ -6,6 +6,12 @@ import useSiteMetadata from "~/src/utils/useSiteMetadata"
 
 import MetaTags from "./MetaTags"
 
+const buildTitle = (siteTitle, pageTitle) => {
+  if (!pageTitle) return siteTitle
+
+  return [siteTitle, pageTitle].join(" | ")
+}
+
 const SEO = ({ description, image, lang, keywords, title, url }) => {
   // Gather the sitewide default metadata as fallback
   const siteMetadata = useSiteMetadata()
@@ -16,7 +22,7 @@ const SEO = ({ description, image, lang, keywords, title, url }) => {
       image,
       lang,
       keywords,
-      title: [siteMetadata.title, title].join(" | "),
+      title: buildTitle(siteMetadata.title, title),
       url,
     },
     siteMetadata


### PR DESCRIPTION
Why:

* #372 refactored the SEO component and introduced an issue where the
  title of the homepage contains the separator that should only be
  visible when there's a page-specific title.

This change addresses the issue by:

* Extracting the title building logic to its own function in the SEO
  component.

Before:
![Screenshot from 2020-09-04 10-37-30](https://user-images.githubusercontent.com/1141870/92225112-ae9b2980-ee9a-11ea-88c6-e3ff810b2f52.png)

After:
![Screenshot from 2020-09-04 10-37-44](https://user-images.githubusercontent.com/1141870/92225127-b35fdd80-ee9a-11ea-9297-a1c6cda097e9.png)

