### PR TITLE
Order blog posts by date and title

### DIFF
--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -10,7 +10,12 @@ import styles from "./blog.module.scss"
 
 const query = graphql`
   {
-    allMarkdownRemark(sort: { order: DESC, fields: [frontmatter___date] }) {
+    allMarkdownRemark(
+      sort: {
+        fields: [frontmatter___date, frontmatter___title]
+        order: [DESC, DESC]
+      }
+    ) {
       nodes {
         frontmatter {
           author {


### PR DESCRIPTION
Why:

* Some blog posts were published with the same date but are meant to
  follow a certain order which can be maintained by their title.