### PR TITLE
Stop rendering HTML in blog post intros

### DIFF
--- a/src/components/blog/posts_list/entry.js
+++ b/src/components/blog/posts_list/entry.js
@@ -26,8 +26,7 @@ const Entry = ({ author, date, intro, path, title }) => {
       </div>
       <p className={styles.intro}>
         <Link to={to}>
-          {/* eslint-disable-next-line react/no-danger */}
-          <span dangerouslySetInnerHTML={{ __html: intro }} />
+          <span>{intro}</span>
         </Link>
       </p>
       <div className={styles.info}>


### PR DESCRIPTION
Why:

* Following #381 blog posts intros no longer have any HTML tags or
  Markdown in them, so we can render them as a normal value.