### PR TITLE
Allow multiline text on the post SEO image generator

### DIFF
--- a/bin/generate-post-meta-image
+++ b/bin/generate-post-meta-image
@@ -1,34 +1,64 @@
 #!/bin/sh -e
+#
+# Example:
+#
+# BG="#222222" bin/generate-multiline-post-meta-image "First line" "Second line" out.png
 
-text="$1"
-bg="$2"
-out=$3
 res=2160x1080
 
 tmp=$(mktemp -d)
 
-if [[ "$bg" == "" ]]; then
-  bg="#2421AB"
-  convert -size $res xc:$bg $tmp/bg.png
+# generate background
+if [[ "$BG" == "" ]]; then
+  BG="#2421AB"
+  convert -size $res xc:$BG $tmp/bg.png
 else
   convert $2 -resize $res^ $tmp/bg-uncropped.png
   convert $tmp/bg-uncropped.png -gravity center -crop $res+0+0 -fill black -colorize 40% $tmp/bg.png
 fi
 
+# generate header
 convert -size $res xc:"#00000000" \
   -pointsize 100 -fill white -draw 'text 100,160 "Blog Post" ' \
   $tmp/text-top.png
 
-convert -size $res xc:"#00000000" \
-  -font ./src/fonts/acta-headline-extra-bold.woff \
-  -pointsize 165 -fill white -draw "text 100,925 '$text' " \
-  $tmp/text-bottom.png
+if [[ "$#" -eq "2" ]]; then
+  files="$tmp/text-top-line.png"
+  top_line="$1"
+  out="$2"
 
-convert \
-  -page +0+0 $tmp/bg.png \
-  -page +0+0 static/script-assets/blog-post-top.png \
-  -page +0+0 $tmp/text-bottom.png \
-  -layers merge +repage $out
+  # generate single lined text
+  convert -size $res xc:"#00000000" \
+    -font ./src/fonts/acta-headline-extra-bold.woff \
+    -pointsize 165 -fill white -draw "text 100,925 '$top_line' " \
+    $tmp/text-top-line.png
+else
+  files="$tmp/text-top-line.png $tmp/text-bottom-line.png"
+  top_line="$1"
+  bottom_line="$2"
+  out="$3"
 
-# Optimize image for smaller footprint
+  # generate double lined text
+  convert -size $res xc:"#00000000" \
+    -font ./src/fonts/acta-headline-extra-bold.woff \
+    -pointsize 165 -fill white -draw "text 100,750 '$top_line' " \
+    $tmp/text-top-line.png
+
+  convert -size $res xc:"#00000000" \
+    -font ./src/fonts/acta-headline-extra-bold.woff \
+    -pointsize 165 -fill white -draw "text 100,925 '$bottom_line' " \
+    $tmp/text-bottom-line.png
+fi
+
+cmd="convert -page +0+0 $tmp/bg.png -page +0+0 static/script-assets/blog-post-top.png"
+
+for file in $files; do
+  cmd="$cmd -page +0+0 $file"
+done
+
+cmd="$cmd -layers merge +repage $out"
+
+`$cmd`
+
+# # Optimize image for smaller footprint
 bundler exec image_optim $out


### PR DESCRIPTION
Previews:

![out](https://user-images.githubusercontent.com/4325027/93320045-813e6c00-f808-11ea-9176-9d229c51190e.png)

![out2](https://user-images.githubusercontent.com/4325027/93320046-826f9900-f808-11ea-96fd-872213901874.png)

In both scenarios, the text is aligned to the bottom (meaning that if you put them side by side, the bottom line should match)