### PR TITLE
Add RSS feed to the blog

### DIFF
--- a/config/gatsby/plugins.js
+++ b/config/gatsby/plugins.js
@@ -4,6 +4,7 @@ const sass = require("sass")
 
 const ROOT = path.resolve(__dirname, "../..")
 
+const rssFeedConfig = require("./plugins/rssFeed")(ROOT)
 const manifestConfig = require("./plugins/manifest")(ROOT)
 
 module.exports = [
@@ -83,6 +84,7 @@ module.exports = [
   "gatsby-transformer-sharp",
   "gatsby-plugin-sharp",
   ...manifestConfig,
+  ...rssFeedConfig,
   {
     resolve: "gatsby-plugin-react-svg",
     options: {

--- a/config/gatsby/plugins/rssFeed.js
+++ b/config/gatsby/plugins/rssFeed.js
@@ -1,0 +1,39 @@
+module.exports = () => [
+  {
+    resolve: "gatsby-plugin-feed",
+    options: {
+      feeds: [
+        {
+          match: "^/blog/",
+          output: "/blog/rss.xml",
+          query: `
+            {
+              allMarkdownRemark(
+                sort: { order: DESC, fields: [frontmatter___date] },
+              ) {
+                nodes {
+                  fields {
+                    slug
+                  },
+                  frontmatter {
+                    date
+                    intro
+                    title
+                  }
+                }
+              }
+            }
+          `,
+          serialize: ({ query: { allMarkdownRemark } }) =>
+            allMarkdownRemark.nodes.map(({ fields, frontmatter }) => ({
+              date: frontmatter.date,
+              description: frontmatter.intro,
+              guid: fields.slug,
+              title: frontmatter.title,
+              url: fields.slug,
+            })),
+        },
+      ],
+    },
+  },
+]

--- a/config/gatsby/siteMetadata.js
+++ b/config/gatsby/siteMetadata.js
@@ -1,12 +1,12 @@
-const url = process.env.URL || "http://localhost:8000"
+const siteUrl = process.env.URL || "http://localhost:8000"
 
 module.exports = {
   description: "We nurture ideas that empower people",
-  image: new URL("/images/meta-image.jpg", url).toString(),
+  image: new URL("/images/meta-image.jpg", siteUrl).toString(),
   lang: "en",
+  siteUrl,
   title: "Subvisual",
   twitter: {
     creator: "@subvisual",
   },
-  url,
 }

--- a/config/node/onCreateNode.js
+++ b/config/node/onCreateNode.js
@@ -40,7 +40,7 @@ const prepareBlogPostSEOImage = ({ node }) => {
   return seoImage
 }
 
-const prepareBlogPostUrl = ({ node }) => {
+const prepareBlogPostSlug = ({ node }) => {
   const { frontmatter } = node
 
   // If `path` is not defined in this post's markdown, exit early
@@ -59,9 +59,9 @@ module.exports = async ({ node, actions }) => {
   const { createNodeField } = actions
   const cover = prepareBlogPostCover({ node })
   const seoImage = prepareBlogPostSEOImage({ node })
-  const url = prepareBlogPostUrl({ node })
+  const slug = prepareBlogPostSlug({ node })
 
   createNodeField({ node, name: "cover", value: cover })
   createNodeField({ node, name: "seoImage", value: seoImage })
-  createNodeField({ node, name: "url", value: url })
+  createNodeField({ node, name: "slug", value: slug })
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "framer-motion": "^1.6.15",
     "gatsby": "^2.1.18",
     "gatsby-image": "^2.2.39",
+    "gatsby-plugin-feed": "^2.5.14",
     "gatsby-plugin-google-analytics": "^2.0.18",
     "gatsby-plugin-manifest": "^2.0.19",
     "gatsby-plugin-netlify-cache": "^1.2.0",

--- a/src/components/SEO/index.jsx
+++ b/src/components/SEO/index.jsx
@@ -25,7 +25,10 @@ const SEO = ({ description, image, lang, keywords, title, url }) => {
       title: buildTitle(siteMetadata.title, title),
       url,
     },
-    siteMetadata
+    siteMetadata,
+    {
+      url: siteMetadata.siteUrl,
+    }
   )
 
   return <MetaTags {...metadata} />

--- a/src/templates/blog/post.js
+++ b/src/templates/blog/post.js
@@ -16,8 +16,8 @@ import "~/src/common/base.scss"
 import styles from "./post.module.scss"
 
 export const query = graphql`
-  query($cover: String, $postPath: String!, $seoImage: String) {
-    markdownRemark(frontmatter: { path: { eq: $postPath } }) {
+  query($cover: String, $seoImage: String, $slug: String!) {
+    markdownRemark(frontmatter: { path: { eq: $slug } }) {
       fields {
         cover
         seoImage

--- a/src/templates/blog/post.js
+++ b/src/templates/blog/post.js
@@ -16,12 +16,12 @@ import "~/src/common/base.scss"
 import styles from "./post.module.scss"
 
 export const query = graphql`
-  query($cover: String, $seoImage: String, $slug: String!) {
-    markdownRemark(frontmatter: { path: { eq: $slug } }) {
+  query($cover: String, $postPath: String!, $seoImage: String) {
+    markdownRemark(frontmatter: { path: { eq: $postPath } }) {
       fields {
         cover
         seoImage
-        url
+        slug
       }
       frontmatter {
         author {
@@ -61,8 +61,8 @@ const BlogPostTemplate = ({
   coverFile,
   date,
   html,
+  slug,
   title,
-  url,
   intro,
   seoDescription,
   seoImage,
@@ -79,7 +79,7 @@ const BlogPostTemplate = ({
         description={seoDescription || intro}
         image={image}
         title={title}
-        url={url}
+        url={slug}
       />
       <div className={styles.root}>
         <article className={styles.article}>
@@ -91,7 +91,7 @@ const BlogPostTemplate = ({
               <BodyWrapper className={styles.innerWrapper}>
                 <Body html={html} />
               </BodyWrapper>
-              <ShareLinks className={styles.shareLinks} url={url} />
+              <ShareLinks className={styles.shareLinks} url={slug} />
             </Wrapper>
           </section>
         </article>

--- a/src/utils/usePathToURL.js
+++ b/src/utils/usePathToURL.js
@@ -4,7 +4,7 @@ export default (path) => {
   // If no path is provided, exit early
   if (!path) return undefined
 
-  const { url } = useSiteMetadata()
+  const { siteUrl } = useSiteMetadata()
 
-  return new URL(path, url).toString()
+  return new URL(path, siteUrl).toString()
 }

--- a/src/utils/useSiteMetadata.js
+++ b/src/utils/useSiteMetadata.js
@@ -8,11 +8,11 @@ function useSiteMetadata() {
         siteMetadata {
           description
           image
+          siteUrl
           title
           twitter {
             creator
           }
-          url
         }
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1035,7 +1035,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.3", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
@@ -6844,6 +6844,17 @@ gatsby-page-utils@^0.2.22:
     lodash "^4.17.15"
     micromatch "^3.1.10"
 
+gatsby-plugin-feed@^2.5.14:
+  version "2.5.14"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-feed/-/gatsby-plugin-feed-2.5.14.tgz#ca46a11b06d7240e0199185c5c30deaed3a118e9"
+  integrity sha512-fMbTpuv1ekL2RU7KGk2o+hc/DGGbAO7kthiM/a8gxT1CqGYh5O6ma9jtqWR1FlTi95gYaWPYiPCyGcIbYurkQA==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    "@hapi/joi" "^15.1.1"
+    fs-extra "^8.1.0"
+    lodash.merge "^4.6.2"
+    rss "^1.2.2"
+
 gatsby-plugin-google-analytics@^2.0.18:
   version "2.3.13"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.3.13.tgz#46f78f4df11cc773d44e5909ea491c8f8c0e6774"
@@ -9699,6 +9710,11 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
 lodash.sample@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/lodash.sample/-/lodash.sample-4.2.1.tgz#5e4291b0c753fa1abeb0aab8fb29df1b66f07f6d"
@@ -10189,6 +10205,18 @@ mime-db@1.44.0, "mime-db@>= 1.43.0 < 2", mime-db@^1.28.0:
   version "1.44.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
+
+mime-db@~1.25.0:
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.25.0.tgz#c18dbd7c73a5dbf6f44a024dc0d165a1e7b1c392"
+  integrity sha1-wY29fHOl2/b0SgJNwNFloeexw5I=
+
+mime-types@2.1.13:
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.13.tgz#e07aaa9c6c6b9a7ca3012c69003ad25a39e92a88"
+  integrity sha1-4HqqnGxrmnyjASxpADrSWjnpKog=
+  dependencies:
+    mime-db "~1.25.0"
 
 mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.27"
@@ -13360,6 +13388,14 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+rss@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/rss/-/rss-1.2.2.tgz#50a1698876138133a74f9a05d2bdc8db8d27a921"
+  integrity sha1-UKFpiHYTgTOnT5oF0r3I240nqSE=
+  dependencies:
+    mime-types "2.1.13"
+    xml "1.0.1"
+
 run-async@^2.2.0, run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
@@ -16133,6 +16169,11 @@ xml2js@^0.4.5:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"
+
+xml@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xmlbuilder@^4.1.0:
   version "4.2.1"


### PR DESCRIPTION
Why:

* https://subvisual.slack.com/archives/C02A7GR2N/p1600641975000600

  We have received some requests for a RSS feed of our blog.

This change addresses the need by:

* Adding the `gatsby-plugin-feed` to generate the RSS feed
  automatically;
* Configuring the generation of a feed exclusively with blog posts, and
  with their data properly configured;
* Refactoring the site metadata to use `siteUrl` for the root URL of the
  website, since it is assumed by `gatsby-plugin-feed` and probably
  other similar plugins.