### PR TITLE
Add author information to the RSS feed

### DIFF
--- a/config/gatsby/plugins/rssFeed.js
+++ b/config/gatsby/plugins/rssFeed.js
@@ -16,6 +16,10 @@ module.exports = () => [
                     slug
                   },
                   frontmatter {
+                    author {
+                      email
+                      name
+                    }
                     date
                     intro
                     title
@@ -25,13 +29,24 @@ module.exports = () => [
             }
           `,
           serialize: ({ query: { allMarkdownRemark } }) =>
-            allMarkdownRemark.nodes.map(({ fields, frontmatter }) => ({
-              date: frontmatter.date,
-              description: frontmatter.intro,
-              guid: fields.slug,
-              title: frontmatter.title,
-              url: fields.slug,
-            })),
+            allMarkdownRemark.nodes.map(({ fields, frontmatter }) => {
+              const { slug } = fields
+              const { author, date, intro, title } = frontmatter
+              const authorEmail = author.email || "contact@subvisual.com"
+
+              return {
+                custom_elements: [
+                  {
+                    author: `${authorEmail} (${author.name})`,
+                  },
+                ],
+                date,
+                description: intro,
+                guid: slug,
+                title,
+                url: slug,
+              }
+            }),
         },
       ],
     },

--- a/config/node/createSchemaCustomization.js
+++ b/config/node/createSchemaCustomization.js
@@ -5,11 +5,13 @@ module.exports = ({ actions }) => {
       interface Author {
         key: String!,
         name: String!,
+        email: String,
       }
 
       type BlogContributorYaml implements Author & Node @dontInfer {
         key: String!,
         bio: String,
+        email: String,
         name: String!,
         social: Social,
       }
@@ -46,6 +48,7 @@ module.exports = ({ actions }) => {
 
       type TeamMemberYaml implements Author & Node @dontInfer {
         key: String!,
+        email: String,
         name: String!,
         photo: Photo!,
         role: String!,

--- a/src/data/team_member.yaml
+++ b/src/data/team_member.yaml
@@ -1,5 +1,6 @@
 - key: fernando-mendes
   name: "Fernando Mendes"
+  email: mendes@subvisual.com
   photo:
     horizontal: "../images/team/fernando-mendes-h.jpg"
     vertical: "../images/team/fernando-mendes-v.jpg"
@@ -96,6 +97,7 @@
 
 - key: miguel-palhas
   name: "Miguel Palhas"
+  email: miguel@subvisual.com
   photo:
     horizontal: "../images/team/miguel-palhas-h.jpg"
     vertical: "../images/team/miguel-palhas-v.jpg"


### PR DESCRIPTION
Why:

* https://subvisual.slack.com/archives/C02A7GR2N/p1602094908003600?thread_ts=1600641975.000600&cid=C02A7GR2N

  It was a feature request from an unknown party we feel like indulging.

This change addresses the need by:

* Adding an email field to authors information;
* Adding a custom field to the RSS feed items with the author
  information, using the company's public contact email address when the
  author did not provide one;
* Adding the email address for Mendes;
  https://subvisual.slack.com/archives/C02A7GR2N/p1602144829008900?thread_ts=1600641975.000600&cid=C02A7GR2N
* Adding the email address for Miguel.
  https://subvisual.slack.com/archives/C02A7GR2N/p1602145455009100?thread_ts=1600641975.000600&cid=C02A7GR2N