### PR TITLE
Configure TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "ua-parser-js": "^0.7.21"
   },
   "devDependencies": {
+    "@types/react-helmet": "^6.1.0",
     "babel-eslint": "^10.1.0",
     "babel-plugin-root-import": "^6.5.0",
     "babel-preset-gatsby": "^0.5.7",
@@ -70,7 +71,8 @@
     "stylelint-config-prettier": "^8.0.1",
     "stylelint-order": "^4.0.0",
     "stylelint-prettier": "^1.1.2",
-    "svgo": "^1.2.0"
+    "svgo": "^1.2.0",
+    "typescript": "^4.0.3"
   },
   "keywords": [
     "gatsby"

--- a/src/components/SEO/MetaTags/Keywords/index.tsx
+++ b/src/components/SEO/MetaTags/Keywords/index.tsx
@@ -1,8 +1,9 @@
 import React from "react"
-import PropTypes from "prop-types"
 import Helmet from "react-helmet"
 
-const Keywords = ({ keywords }) => {
+import { Component } from "./types"
+
+const Keywords : Component = ({ keywords }) => {
   if (!keywords || keywords.length === 0) return null
 
   const content = keywords.join(`, `)
@@ -12,10 +13,6 @@ const Keywords = ({ keywords }) => {
       <meta name="keywords" content={content} />
     </Helmet>
   )
-}
-
-Keywords.propTypes = {
-  keywords: PropTypes.arrayOf(PropTypes.string),
 }
 
 export default Keywords

--- a/src/components/SEO/MetaTags/Keywords/types.d.ts
+++ b/src/components/SEO/MetaTags/Keywords/types.d.ts
@@ -1,0 +1,7 @@
+export interface Props {
+  readonly keywords?: ReadonlyArray<string>
+}
+
+export interface Component {
+  (props: Props): JSX.Element | null
+}

--- a/src/components/SEO/MetaTags/OpenGraph/index.tsx
+++ b/src/components/SEO/MetaTags/OpenGraph/index.tsx
@@ -1,8 +1,9 @@
 import React from "react"
-import PropTypes from "prop-types"
 import Helmet from "react-helmet"
 
-const OpenGraph = ({ description, image, title, url }) => (
+import { Component } from "./types"
+
+const OpenGraph : Component = ({ description, image, title, url }) => (
   <Helmet>
     <meta property="og:description" content={description} />
     <meta property="og:image" content={image} />
@@ -11,12 +12,5 @@ const OpenGraph = ({ description, image, title, url }) => (
     <meta property="og:url" content={url} />
   </Helmet>
 )
-
-OpenGraph.propTypes = {
-  description: PropTypes.string,
-  image: PropTypes.string,
-  title: PropTypes.string,
-  url: PropTypes.string,
-}
 
 export default OpenGraph

--- a/src/components/SEO/MetaTags/OpenGraph/types.d.ts
+++ b/src/components/SEO/MetaTags/OpenGraph/types.d.ts
@@ -1,0 +1,10 @@
+export interface Props {
+  readonly description?: string,
+  readonly image?: string,
+  readonly title?: string,
+  readonly url?: string,
+}
+
+export interface Component {
+  (props: Props): JSX.Element
+}

--- a/src/components/SEO/MetaTags/Twitter/index.tsx
+++ b/src/components/SEO/MetaTags/Twitter/index.tsx
@@ -1,8 +1,9 @@
 import React from "react"
-import PropTypes from "prop-types"
 import Helmet from "react-helmet"
 
-const Twitter = ({ creator, description, image, title, url }) => (
+import { Component } from "./types"
+
+const Twitter : Component = ({ creator, description, image, title, url }) => (
   <Helmet>
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:creator" content={creator} />
@@ -12,13 +13,5 @@ const Twitter = ({ creator, description, image, title, url }) => (
     <meta property="twitter:url" content={url} />
   </Helmet>
 )
-
-Twitter.propTypes = {
-  creator: PropTypes.string,
-  description: PropTypes.string,
-  image: PropTypes.string,
-  title: PropTypes.string,
-  url: PropTypes.string,
-}
 
 export default Twitter

--- a/src/components/SEO/MetaTags/Twitter/types.d.ts
+++ b/src/components/SEO/MetaTags/Twitter/types.d.ts
@@ -1,0 +1,11 @@
+export interface Props {
+  readonly creator?: string
+  readonly description?: string
+  readonly image?: string
+  readonly title?: string
+  readonly url?: string
+}
+
+export interface Component {
+  (props: Props): JSX.Element
+}

--- a/src/components/SEO/MetaTags/index.tsx
+++ b/src/components/SEO/MetaTags/index.tsx
@@ -1,12 +1,12 @@
 import React from "react"
-import PropTypes from "prop-types"
 import Helmet from "react-helmet"
 
 import Keywords from "./Keywords"
 import OpenGraph from "./OpenGraph"
 import Twitter from "./Twitter"
+import { Component } from "./types"
 
-const MetaTags = ({
+const MetaTags : Component = ({
   description,
   image,
   lang,
@@ -25,14 +25,5 @@ const MetaTags = ({
     <Twitter {...{ description, image, title, url, ...twitter }} />
   </>
 )
-
-MetaTags.propTypes = {
-  description: PropTypes.string,
-  image: PropTypes.string,
-  lang: PropTypes.string,
-  title: PropTypes.string,
-  twitter: PropTypes.object,
-  url: PropTypes.string,
-}
 
 export default MetaTags

--- a/src/components/SEO/MetaTags/types.d.ts
+++ b/src/components/SEO/MetaTags/types.d.ts
@@ -1,0 +1,13 @@
+export interface Props {
+  description?: string
+  image?: string
+  lang?: string
+  keywords?: ReadonlyArray<string>
+  title?: string
+  twitter?: object
+  url?: string
+}
+
+export interface Component {
+  (props: Props): JSX.Element
+}

--- a/src/components/SEO/index.tsx
+++ b/src/components/SEO/index.tsx
@@ -1,18 +1,18 @@
 import React from "react"
-import PropTypes from "prop-types"
 import _defaults from "lodash/defaults"
 
 import useSiteMetadata from "~/src/utils/useSiteMetadata"
 
 import MetaTags from "./MetaTags"
+import { Component } from "./types"
 
-const buildTitle = (siteTitle, pageTitle) => {
+const buildTitle = (siteTitle: string, pageTitle?: string): string => {
   if (!pageTitle) return siteTitle
 
   return [siteTitle, pageTitle].join(" | ")
 }
 
-const SEO = ({ description, image, lang, keywords, title, url }) => {
+const SEO : Component = ({ description, image, lang, keywords, title, url }) => {
   // Gather the sitewide default metadata as fallback
   const siteMetadata = useSiteMetadata()
 
@@ -32,15 +32,6 @@ const SEO = ({ description, image, lang, keywords, title, url }) => {
   )
 
   return <MetaTags {...metadata} />
-}
-
-SEO.propTypes = {
-  description: PropTypes.string,
-  image: PropTypes.string,
-  lang: PropTypes.string,
-  title: PropTypes.string,
-  twitter: PropTypes.object,
-  url: PropTypes.string,
 }
 
 export default SEO

--- a/src/components/SEO/types.d.ts
+++ b/src/components/SEO/types.d.ts
@@ -1,0 +1,12 @@
+export interface Props {
+  readonly description?: string
+  readonly image?: string
+  readonly lang?: string
+  readonly keywords?: ReadonlyArray<string>
+  readonly title?: string
+  readonly url?: string
+}
+
+export interface Component {
+  (readonly props: Props): JSX.Element
+}

--- a/src/utils/useSiteMetadata/index.ts
+++ b/src/utils/useSiteMetadata/index.ts
@@ -1,7 +1,9 @@
 import { graphql, useStaticQuery } from "gatsby"
 import _get from "lodash/get"
 
-function useSiteMetadata() {
+import { SiteMetadata } from "./types"
+
+export default () : SiteMetadata => {
   const data = useStaticQuery(graphql`
     query {
       site {
@@ -20,5 +22,3 @@ function useSiteMetadata() {
 
   return _get(data, "site.siteMetadata")
 }
-
-export default useSiteMetadata

--- a/src/utils/useSiteMetadata/types.d.ts
+++ b/src/utils/useSiteMetadata/types.d.ts
@@ -1,0 +1,12 @@
+export interface TwitterMetadata {
+  creator: string
+}
+
+export interface SiteMetadata {
+  description: string
+  image: string
+  lang: string
+  siteUrl: string
+  title: string
+  twitter: TwitterMetadata
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "preserve",
+    "module": "commonjs",
+    "noEmit": true,
+    "paths": {
+      "~/*": ["./*"]
+    },
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es5"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2140,6 +2140,13 @@
     "@types/history" "*"
     "@types/react" "*"
 
+"@types/react-helmet@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-6.1.0.tgz#af586ed685f4905e2adc7462d1d65ace52beee7a"
+  integrity sha512-PYRoU1XJFOzQ3BHvWL1T8iDNbRjdMDJMT5hFmZKGbsq09kbSqJy61uwEpTrbTNWDopVphUT34zUSVLK9pjsgYQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*":
   version "16.9.48"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.48.tgz#d3387329f070d1b1bc0ff4a54a54ceefd5a8485c"
@@ -15180,6 +15187,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
+  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
 
 ua-parser-js@^0.7.21:
   version "0.7.21"


### PR DESCRIPTION
Why:

* GatsbyJS now ships with full TypeScript support, which means we can
  make use of it for most of the website's source code. In particular
  for React components, it allows us to drop `PropTypes`, which does not
  actually prevent any bad typing, in favor of TypeScript type checking
  in the CI.

This change addresses the need by:

* Configuring the TypeScript compiler to allow for an easy conversion of
  our components;
* Refactoring the SEO component as an example and showcase of the end
  result with TypeScript.