### PR TITLE
Refactor generated CSS module class names

### DIFF
--- a/config/gatsby/plugins.js
+++ b/config/gatsby/plugins.js
@@ -1,26 +1,13 @@
 const path = require("path")
-const postCssUrl = require("postcss-url")
-const sass = require("sass")
 
 const ROOT = path.resolve(__dirname, "../..")
 
+const sassConfig = require("./plugins/sass")(ROOT)
 const rssFeedConfig = require("./plugins/rssFeed")(ROOT)
 const manifestConfig = require("./plugins/manifest")(ROOT)
 
 module.exports = [
-  {
-    resolve: "gatsby-plugin-sass",
-    options: {
-      implementation: sass,
-      includePaths: [
-        path.resolve(ROOT, "node_modules"),
-        path.resolve(ROOT, "src"),
-      ],
-      postCssPlugins: [
-        postCssUrl([{ filter: "**/fonts/inline/*", url: "inline" }]),
-      ],
-    },
-  },
+  ...sassConfig,
   "gatsby-plugin-react-helmet",
   "gatsby-transformer-yaml",
   {

--- a/config/gatsby/plugins/sass.js
+++ b/config/gatsby/plugins/sass.js
@@ -1,0 +1,27 @@
+const path = require("path")
+const postCssUrl = require("postcss-url")
+const sass = require("sass")
+
+module.exports = (root) => [
+  {
+    resolve: "gatsby-plugin-sass",
+    options: {
+      cssLoaderOptions: {
+        localIdentName: "[folder]-[name]--[local]--[hash:base64:5]",
+      },
+      implementation: sass,
+      includePaths: [
+        path.resolve(root, "node_modules"),
+        path.resolve(root, "src"),
+      ],
+      postCssPlugins: [
+        postCssUrl([
+          {
+            filter: "**/fonts/inline/*",
+            url: "inline",
+          },
+        ]),
+      ],
+    },
+  },
+]


### PR DESCRIPTION
Why:

* By default Gatsby uses only the name of the module it gets from the
  filename, which means that most of our CSS modules become
  `index-something-XXXXX` when nesting all the files related to a
  component in a single directory (due to CSS module files being named
  `index.module.(s)css`.

This change addresses the issue by:

* Tweaking `localIdentName` in the CSS Webpack loader so it uses the
  folder in the generated class name, by prepending the folder
  interpolation to the GatsbyJS default value for `localIdentName`
  (copied from [the source])

[the source]: https://github.com/gatsbyjs/gatsby/blob/18c182a574475c9c06dbbeb7ddae27f5cb008fe9/packages/gatsby/src/utils/webpack-utils.ts#L216