### PR TITLE
Reduce text size for Norte2020 document links

### DIFF
--- a/src/components/layout/footer/Norte2020/index.module.scss
+++ b/src/components/layout/footer/Norte2020/index.module.scss
@@ -13,6 +13,8 @@
 }
 
 .link {
+  font-size: 12px;
+  line-height: 16px;
   text-align: center;
 
   @include media(">=400px") {
@@ -22,6 +24,9 @@
   }
 
   @include media(">=desktop") {
+    font-size: 16px;
+    line-height: 20px;
+
     & + & {
       margin-top: 0;
       margin-left: 28px;


### PR DESCRIPTION
Why:

* https://3.basecamp.com/4319812/buckets/19267320/todos/3138565689#__recording_3177522445
* https://3.basecamp.com/4319812/buckets/19267320/todos/3138565689#__recording_3183123234