### PR TITLE
Fix announcement banner copy

### DIFF
--- a/src/components/AnnouncementBanner/index.jsx
+++ b/src/components/AnnouncementBanner/index.jsx
@@ -9,7 +9,7 @@ export default () => (
   <div className={styles.root}>
     <Announcement
       title="We're hiring!"
-      subtitle="Would you like to join our team? Head down to our blog and read on our front-end developer opening."
+      subtitle="Would you like to join our team? Head over to our jobs page and read on our current openings."
       link="https://jobs.subvisual.com"
       daysToLive={0}
       secondsBeforeBannerShows={10}


### PR DESCRIPTION
Why:

* https://3.basecamp.com/4319812/buckets/14602877/todos/3078612807#__recording_3180018623

  We changed the link to our jobs page but forgot to update the copy,
  which is still referring the blog post.