### PR TITLE
Adds WebP support to both sharp and remark image loaders

### DIFF
--- a/config/gatsby/plugins.js
+++ b/config/gatsby/plugins.js
@@ -50,6 +50,7 @@ module.exports = [
         {
           resolve: "gatsby-remark-images",
           options: {
+            withWebp: true,
             maxWidth: 834,
             linkImagesToOriginal: false,
             quality: 85,

--- a/src/components/home/about_section/team_subsection.js
+++ b/src/components/home/about_section/team_subsection.js
@@ -17,14 +17,14 @@ const teamQuery = graphql`
             horizontal {
               childImageSharp {
                 fluid(maxWidth: 340, quality: 80) {
-                  ...GatsbyImageSharpFluid_noBase64
+                  ...GatsbyImageSharpFluid_withWebp_noBase64
                 }
               }
             }
             vertical {
               childImageSharp {
                 fluid(maxWidth: 275, quality: 80) {
-                  ...GatsbyImageSharpFluid_noBase64
+                  ...GatsbyImageSharpFluid_withWebp_noBase64
                 }
               }
             }

--- a/src/components/home/hero_section.js
+++ b/src/components/home/hero_section.js
@@ -175,14 +175,14 @@ const query = graphql`
     hero1_v: file(relativePath: { regex: "/hero-1-vertical.jpg/" }) {
       childImageSharp {
         fluid(maxHeight: 700, quality: 95) {
-          ...GatsbyImageSharpFluid_noBase64
+          ...GatsbyImageSharpFluid_withWebp_noBase64
         }
       }
     }
     hero1_h: file(relativePath: { regex: "/hero-1-horizontal.jpg/" }) {
       childImageSharp {
         fluid(maxHeight: 224, quality: 95) {
-          ...GatsbyImageSharpFluid_noBase64
+          ...GatsbyImageSharpFluid_withWebp_noBase64
         }
       }
     }
@@ -190,14 +190,14 @@ const query = graphql`
     hero2_v: file(relativePath: { regex: "/hero-2-vertical.jpg/" }) {
       childImageSharp {
         fluid(maxHeight: 700, quality: 95) {
-          ...GatsbyImageSharpFluid_noBase64
+          ...GatsbyImageSharpFluid_withWebp_noBase64
         }
       }
     }
     hero2_h: file(relativePath: { regex: "/hero-2-horizontal.jpg/" }) {
       childImageSharp {
         fluid(maxHeight: 224, quality: 95) {
-          ...GatsbyImageSharpFluid_noBase64
+          ...GatsbyImageSharpFluid_withWebp_noBase64
         }
       }
     }
@@ -205,14 +205,14 @@ const query = graphql`
     hero3_v: file(relativePath: { regex: "/hero-3-vertical.jpg/" }) {
       childImageSharp {
         fluid(maxHeight: 700, quality: 85) {
-          ...GatsbyImageSharpFluid_noBase64
+          ...GatsbyImageSharpFluid_withWebp_noBase64
         }
       }
     }
     hero3_h: file(relativePath: { regex: "/hero-3-horizontal.jpg/" }) {
       childImageSharp {
         fluid(maxHeight: 320, quality: 95) {
-          ...GatsbyImageSharpFluid_noBase64
+          ...GatsbyImageSharpFluid_withWebp_noBase64
         }
       }
     }

--- a/src/components/home/ventures_section/portfolio_subsection.js
+++ b/src/components/home/ventures_section/portfolio_subsection.js
@@ -68,7 +68,7 @@ const query = graphql`
           image {
             childImageSharp {
               fluid(maxHeight: 720, quality: 85) {
-                ...GatsbyImageSharpFluid_noBase64
+                ...GatsbyImageSharpFluid_withWebp_noBase64
               }
             }
           }

--- a/src/components/layout/footer/Norte2020/index.jsx
+++ b/src/components/layout/footer/Norte2020/index.jsx
@@ -41,7 +41,7 @@ const query = graphql`
     logo: file(relativePath: { regex: "/norte-2020-logos.jpg/" }) {
       childImageSharp {
         fluid(maxWidth: 650, quality: 100) {
-          ...GatsbyImageSharpFluid_noBase64
+          ...GatsbyImageSharpFluid_withWebp_noBase64
         }
       }
     }

--- a/src/components/layout/footer/location.js
+++ b/src/components/layout/footer/location.js
@@ -13,14 +13,14 @@ const query = graphql`
     boston: file(relativePath: { regex: "/boston.jpg/" }) {
       childImageSharp {
         fluid(maxWidth: 725, quality: 85) {
-          ...GatsbyImageSharpFluid_noBase64
+          ...GatsbyImageSharpFluid_withWebp_noBase64
         }
       }
     }
     braga: file(relativePath: { regex: "/braga.jpg/" }) {
       childImageSharp {
         fluid(maxWidth: 725, quality: 85) {
-          ...GatsbyImageSharpFluid_noBase64
+          ...GatsbyImageSharpFluid_withWebp_noBase64
         }
       }
     }

--- a/src/templates/blog/post.js
+++ b/src/templates/blog/post.js
@@ -38,14 +38,14 @@ export const query = graphql`
     coverFile: file(absolutePath: { eq: $cover }) {
       childImageSharp {
         fluid(grayscale: true, maxWidth: 980) {
-          ...GatsbyImageSharpFluid
+          ...GatsbyImageSharpFluid_withWebp
         }
       }
     }
     seoImageFile: file(absolutePath: { eq: $seoImage }) {
       childImageSharp {
         fixed(width: 2160, height: 1080) {
-          ...GatsbyImageSharpFixed_noBase64
+          ...GatsbyImageSharpFixed_withWebp_noBase64
         }
       }
     }


### PR DESCRIPTION
Because modern image compression.

Before (only our homepage hero):
![image](https://user-images.githubusercontent.com/283819/101640500-7d497100-3a28-11eb-81cd-b21b59731b65.png)

After:
![image](https://user-images.githubusercontent.com/283819/101640537-889c9c80-3a28-11eb-9bc7-8484ec715441.png)
