### PR TITLE
Disable default SEO images locally

### DIFF
--- a/config/node/createPages.js
+++ b/config/node/createPages.js
@@ -62,7 +62,7 @@ const createBlogPostsPages = async ({ createPage, graphql }) => {
       component,
       context: {
         cover,
-        seoImage,
+        seoImage: seoImage || cover,
         slug,
         title: frontmatter.title,
         isBlogPost: true,

--- a/plugins/seo-cover/gatsby-node.js
+++ b/plugins/seo-cover/gatsby-node.js
@@ -59,7 +59,7 @@ module.exports.onCreatePage = async ({ page, actions }) => {
   const { createPage, deletePage } = actions
 
   if (!page.context || !page.context.isBlogPost) return
-  if (page.context.seoImage && fs.existsSync(page.context.seoImage)) return
+  if (page.context.seoImage) return
 
   const automaticSEOFile = path.join("public", page.path, FILE_NAME)
 

--- a/plugins/seo-cover/gatsby-node.js
+++ b/plugins/seo-cover/gatsby-node.js
@@ -62,9 +62,16 @@ module.exports.onCreatePage = async ({ page, actions }) => {
   if (!page.context || !page.context.isBlogPost) return
   if (page.context.seoImage || page.context.cover) return
 
+  const automaticSEOFile = path.join("public", page.path, FILE_NAME)
+
+  if (fs.existsSync(automaticSEOFile)) return
+
+  if (process.env.NODE_ENV !== "production")
+    return console.warn("SEO images are only generated in production")
+
   await transform({
     text: page.context.title,
-    path: path.join("public", page.path, FILE_NAME),
+    path: automaticSEOFile,
   })
 
   const oldPage = Object.assign({}, page)


### PR DESCRIPTION
Disabling the generation of default SEO images locally and not re-generating when they already exist changes the start time from a couple of minutes to almost instant.