### PR TITLE
Add photo and initials to author page

### DIFF
--- a/src/templates/Author/index.jsx
+++ b/src/templates/Author/index.jsx
@@ -25,6 +25,18 @@ export const query = graphql`
           author {
             key
             name
+            initials
+            photo {
+              vertical {
+                childImageSharp {
+                  gatsbyImageData(
+                    width: 50
+                    height: 50
+                    transformOptions: { fit: COVER, cropFocus: ATTENTION }
+                  )
+                }
+              }
+            }
           }
           date
           title


### PR DESCRIPTION
Why:
* Author page was missing initials and photo which was causing it to show an empty avatar

These changes address the need by:
* Add query for initials and photo on the author template