### PR TITLE
Change header z-index

### DIFF
--- a/src/components/Header/index.module.scss
+++ b/src/components/Header/index.module.scss
@@ -2,7 +2,7 @@
   position: fixed;
 
   top: 0;
-  z-index: 1;
+  z-index: 2;
 
   display: flex;
   align-items: baseline;


### PR DESCRIPTION
Why:
- Closes #540 

These changes address the need by:
- Change the navbar z-index to make it a higher value than the highlighted posts slider