### PR TITLE
Replace opacity for color in PostList

### DIFF
--- a/src/components/PostList/index.module.scss
+++ b/src/components/PostList/index.module.scss
@@ -66,12 +66,7 @@
 }
 
 .info {
-  display: flex;
-  align-items: center;
-
-  opacity: 0.6;
-
-  font-family: colfax-web;
+  color: rgba(#403f4c, 0.6);
 }
 
 .categories {


### PR DESCRIPTION
Why:
- Author component had less opacity meaning that the Author's picture had some transparency

These changes address the need by:
- Replace opacity in PostList for a color