### PR TITLE
Renaming the tag "Operations" to "Company Building"

### DIFF
--- a/src/data/category.yaml
+++ b/src/data/category.yaml
@@ -12,5 +12,5 @@
   label: Inside Subvisual
 - key: academy
   label: Academy
-- key: operations
-  label: Operations
+- key: company-building
+  label: Company Building

--- a/src/posts/2022-04-28-how-we-nurture-a-work-life-balance-culture/index.md
+++ b/src/posts/2022-04-28-how-we-nurture-a-work-life-balance-culture/index.md
@@ -2,7 +2,7 @@
 path: how-to-nurture-a-worklife-balance
 title: "How we nurture a work/life balance culture "
 categories:
-  - operations
+  - company-building
 author: subvisual
 date: 2022-04-28
 cover: meta.jpg

--- a/src/posts/2023-03-09-7-steps-to-a-better-company-culture/index.md
+++ b/src/posts/2023-03-09-7-steps-to-a-better-company-culture/index.md
@@ -2,7 +2,7 @@
 path: seven-steps-to-a-better-company-culture
 title: 7 Steps to a Better Company Culture
 categories:
-  - operations
+  - company-building
 author: laura-esteves
 date: 2023-03-10
 cover: subvisual-blog-7-steps-to-a-better-company-culture.png

--- a/src/posts/2023-09-05-the-power-of-company-retreats/index.md
+++ b/src/posts/2023-09-05-the-power-of-company-retreats/index.md
@@ -3,7 +3,7 @@ highlight: true
 path: The-Power-of-Company-Retreats
 title: The Power of Company Retreats
 categories:
-  - operations
+  - company-building
 author: laura-esteves
 date: 2023-09-05
 cover: blog_-_the_power_of_company_retreats.jpg

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -35,7 +35,7 @@ collections:
           - { value: 'research', label: 'Research' }
           - { value: 'inside-subvisual', label: 'Inside Subvisual' }
           - { value: 'academy', label: 'Academy' }
-          - { value: 'operations', label: 'Operations' }
+          - { value: 'company-building', label: 'Company Building' }
       - label: 'Author'
         name: 'author'
         widget: 'select'


### PR DESCRIPTION
Why:
* #576

How:
* Changing the relevant occurences of `operations` to `company-building`
  and `Operations` to `Company Building`
