### PR TITLE
Add RSS feed for tech content

### DIFF
--- a/config/gatsby/plugins/rssFeed.js
+++ b/config/gatsby/plugins/rssFeed.js
@@ -49,6 +49,56 @@ module.exports = () => [
               }
             }),
         },
+        {
+          match: "^/blog/",
+          output: "/blog/rss_tech.xml",
+          title: "Subvisual",
+          query: `
+            {
+              allMarkdownRemark(
+                sort: { order: DESC, fields: [frontmatter___date] },
+                filter: { frontmatter: { categories: { elemMatch: { key: { eq: "engineering" }}}}},
+              ) {
+                nodes {
+                  fields {
+                   url
+                  },
+                  frontmatter {
+                    author {
+                      email
+                      name
+                    }
+                    categories {
+                      key
+                    }
+                    date
+                    intro
+                    title
+                  }
+                }
+              }
+            }
+          `,
+          serialize: ({ query: { allMarkdownRemark } }) =>
+            allMarkdownRemark.nodes.map(({ fields, frontmatter }) => {
+              const { url } = fields
+              const { author, date, intro, title } = frontmatter
+              const authorEmail = author.email || "contact@subvisual.com"
+
+              return {
+                custom_elements: [
+                  {
+                    author: `${authorEmail} (${author.name})`,
+                  },
+                ],
+                date,
+                description: intro,
+                guid: url,
+                title,
+                url,
+              }
+            }),
+        },
       ],
     },
   },


### PR DESCRIPTION
Why:
* #577

How:
* Adding a new feed to the `feeds` list that only fetches posts with the
  `engineering` category
